### PR TITLE
Feature Add notes  (#147)

### DIFF
--- a/WHMapper.Tests/WHMapper.Tests.csproj
+++ b/WHMapper.Tests/WHMapper.Tests.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -19,8 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
-    <PackageReference Include="Npgsql" Version="7.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
+    <PackageReference Include="Npgsql" Version="7.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Xunit.Priority" Version="1.1.6" />
   </ItemGroup>

--- a/WHMapper/Pages/Mapper/CustomNode/EveSystemNode.cs
+++ b/WHMapper/Pages/Mapper/CustomNode/EveSystemNode.cs
@@ -19,24 +19,12 @@ namespace WHMapper.Pages.Mapper.CustomNode
 {
     public partial class EveSystemNode : ComponentBase
     {
-        private const string MENU_LOCK_SYSTEM_VALUE = "Lock";
-        private const string MENU_UNLOCK_SYSTEM_VALUE = "Unlock";
-
-
         private EveSystemNodeModel _node = null!;
 
         private string _secColor = IWHColorHelper.DEFAULT_COLOR;
         private string _systemColor = IWHColorHelper.DEFAULT_COLOR;
         private string _whEffectColor = IWHColorHelper.DEFAULT_COLOR;
-        private string _menu_lock_value = MENU_LOCK_SYSTEM_VALUE;
-        private string _menu_lock_icon_value = Icons.Material.Sharp.Lock;
 
-
-        [Inject]
-        IEveAPIServices EveServices { get; set; } = null!;
-
-        [Inject]
-        IWHSystemRepository DbWHSystems { get; set; } = null!;
 
         [Inject]
         public ILogger<EveSystemNode> Logger { get; set; } = null!;
@@ -61,97 +49,8 @@ namespace WHMapper.Pages.Mapper.CustomNode
                     _secColor = WHColorHelper.GetSecurityStatusColor(_node.SecurityStatus);
                     _systemColor = WHColorHelper.GetSystemTypeColor(_node.SystemType);
                     _whEffectColor = WHColorHelper.GetEffectColor(_node.Effect);
-
-                    Locked = _node.Locked;
-
                 }
             }
-        }
-
-        private bool Locked
-        {
-            get
-            {
-                if (_node != null)
-                    return _node.Locked;
-                else
-                    return false;
-            }
-            set
-            {
-                if(_node!=null)
-                {
-                    _node.Locked = value;
-
-                    if (_node.Locked)
-                    {
-                        _menu_lock_value = MENU_UNLOCK_SYSTEM_VALUE;
-                        _menu_lock_icon_value = Icons.Material.Sharp.LockOpen;
-                    }
-                    else
-                    {
-                        _menu_lock_value = MENU_LOCK_SYSTEM_VALUE;
-                        _menu_lock_icon_value = Icons.Material.Sharp.Lock;
-                    }
-                    StateHasChanged();
-                }
-            }
-        }
-
-
-
-        private async Task<bool> SetSelectedSystemDestinationWaypoint()
-        {
-            try
-            {
-                if (_node.Selected)
-                {
-                    var res = await EveServices.UserInterfaceServices.SetWaypoint(_node.SolarSystemId, false, true);
-                    return true;
-
-                }
-
-                return false;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Set destination waypoint error");
-                return false;
-            }
-        }
-
-        private async Task<bool> ToggleSystemLock()
-        {
-            try
-            {
-                var whSystem = await DbWHSystems.GetById(_node.IdWH);
-                if (whSystem != null && whSystem.Id==_node.IdWH)
-                {
-                    whSystem.Locked = !whSystem.Locked;
-                    whSystem = await DbWHSystems.Update(whSystem.Id, whSystem);
-                    if (whSystem == null)
-                    {
-                        Logger.LogError("Update lock system status error");
-                        return false;
-                    }
-
-                    Locked = whSystem.Locked;
-                    _node.Refresh();
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
-          
-
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "Toggle destination waypoint error");
-                return false;
-            }
-         
         }
     }
 }

--- a/WHMapper/Pages/Mapper/CustomNode/EveSystemNode.razor
+++ b/WHMapper/Pages/Mapper/CustomNode/EveSystemNode.razor
@@ -3,83 +3,74 @@
 @using WHMapper.Models.DTO.EveMapper.Enums;
 
 
-<MudMenu PositionAtCursor="true" ActivationEvent="@MouseEvent.RightClick" Dense="true">
-    <ActivatorContent>
-        <MudCard Outlined="true" Style="@(Node.Selected ? "border-color:white;" : "border-color:grey;")">
-            <MudCardHeader Class="mb-n5">
-                <CardHeaderAvatar>
-                    <MudBadge Origin="Origin.TopRight" Overlap="true" Content=@Node.NameExtension Visible=@((Node.NameExtension!=null) ? true : false) Bordered="true" Color="Color.Dark">
-                        <MudAvatar class="mt-1" Style="@($"color:{_systemColor}; border-color:{_systemColor}; font-weight:bold;")" Size="Size.Small" Variant="Variant.Outlined">@Node.SystemType.ToDescriptionString()</MudAvatar>
-                    </MudBadge>
-                </CardHeaderAvatar>
-                <CardHeaderContent>
-                    <MudText class="ml-n1 pr-2 mt-1" Typo="Typo.body2" Style="font-weight:bold;">@Node.Name</MudText>
-                </CardHeaderContent>
-                <CardHeaderActions>
-                    @if (Locked)
-                    {
-                        <MudIcon Icon="@Icons.Material.Sharp.Lock" DisableElevation="true" Size="Size.Small" Style="margin-top:-3px" />
-                    }
-                    @if (Node != null && Node.Effect != WHMapper.Models.DTO.EveMapper.Enums.WHEffect.None)
-                    {
-                        <MudTooltip Text="@Node.Effect.ToString()" Arrow="true" Placement="Placement.Bottom">
-                            <ChildContent>
-                                <MudIcon Icon="@Icons.Material.Filled.Square" DisableElevation="true" Style="@($"color:{_whEffectColor};")" Size="Size.Small" />
-                            </ChildContent>
-                            <TooltipContent>
-                                <MudPaper Class="d-flex flex-column flex-grow-1 gap-1" Elevation="0">
-                                    @foreach (var effectInfo in Node.EffectDetails)
-                                    {
-                                        <MudText class="ml-1 mr-1" Typo="Typo.caption">@effectInfo.Name. : @effectInfo.Value%</MudText>
-                                    }
-                                </MudPaper>
-                            </TooltipContent>
-                        </MudTooltip>
-                    }
-                </CardHeaderActions>
-            </MudCardHeader>
 
-            <MudCardContent Class="d-flex pa-1 pr-2 justify-space-between">
-                <div Class="d-flex justify-start">
-                    @if (Node != null && Node.ConnectedUsers != null && Node.ConnectedUsers.FirstOrDefault() != null)
-                    {
-                        <MudTooltip Typo="Typo.caption" Arrow="true" Placement="Placement.Bottom">
-                            <ChildContent>
-                                <MudIcon Icon="@Icons.Material.Filled.Group" Color=Color.Default Size="Size.Small" />
-                            </ChildContent>
-                            <TooltipContent>
-                                <MudPaper Class="d-flex flex-column flex-grow-1 gap-1" Elevation="0">
-                                    @foreach (var user in @Node.ConnectedUsers)
-                                    {
-                                        <MudText class="ml-1 mr-1" Typo="Typo.caption">@user</MudText>
-                                    }
-                                </MudPaper>
-                            </TooltipContent>
-                        </MudTooltip>
-                    }
-                    else
-                    {
-                        <MudIcon Icon="@Icons.Material.Filled.Group" Color=Color.Transparent Size="Size.Small" />
-                    }
-                    <MudText Class="align-self-stretch ml-1 mt-1" Typo="Typo.caption">@Node?.ConnectedUsers.FirstOrDefault()</MudText>
-                </div>
-                <div Class="d-flex justify-end">
-                    @if (Node != null && Node.Statics != null && Node?.Statics.Count() > 0)
-                    {
-                        @foreach (var item in Node.Statics)
-                        {
-                            <MudText Class="align-self-stretch mt-1 ml-1" Typo="Typo.body2" Style="@($"color:{WHColorHelper.GetSystemTypeColor(@item.EveSystemDestinationType)};")">@item.EveSystemDestinationType.ToString()</MudText>
-                        }
-                    }
-                </div>
-            </MudCardContent>
-        </MudCard>
-    </ActivatorContent>
-    <ChildContent>
-        <MudMenuItem OnClick="@(() =>SetSelectedSystemDestinationWaypoint())" Icon="@Icons.Material.Sharp.FlagCircle" Size="Size.Small">Set Destination</MudMenuItem>
-        <MudMenuItem OnClick="@(() =>ToggleSystemLock())" Icon="@_menu_lock_icon_value" Size="Size.Small">@_menu_lock_value</MudMenuItem>
-    </ChildContent>
-</MudMenu>
+<MudCard Outlined="true" Style="@(Node.Selected ? "border-color:white;" : "border-color:grey;")">
+    <MudCardHeader Class="mb-n5">
+        <CardHeaderAvatar>
+            <MudBadge Origin="Origin.TopRight" Overlap="true" Content=@Node.NameExtension Visible=@((Node.NameExtension!=null) ? true : false) Bordered="true" Color="Color.Dark">
+                <MudAvatar class="mt-1" Style="@($"color:{_systemColor}; border-color:{_systemColor}; font-weight:bold;")" Size="Size.Small" Variant="Variant.Outlined">@Node.SystemType.ToDescriptionString()</MudAvatar>
+            </MudBadge>
+        </CardHeaderAvatar>
+        <CardHeaderContent>
+            <MudText class="ml-n1 pr-2 mt-1" Typo="Typo.body2" Style="font-weight:bold;">@Node.Name</MudText>
+        </CardHeaderContent>
+        <CardHeaderActions>
+            @if (_node.Locked)
+            {
+                <MudIcon Icon="@Icons.Material.Sharp.Lock" DisableElevation="true" Size="Size.Small" Style="margin-top:-3px" />
+            }
+            @if (Node != null && Node.Effect != WHMapper.Models.DTO.EveMapper.Enums.WHEffect.None)
+            {
+                <MudTooltip Text="@Node.Effect.ToString()" Arrow="true" Placement="Placement.Bottom">
+                    <ChildContent>
+                        <MudIcon Icon="@Icons.Material.Filled.Square" DisableElevation="true" Style="@($"color:{_whEffectColor};")" Size="Size.Small" />
+                    </ChildContent>
+                    <TooltipContent>
+                        <MudPaper Class="d-flex flex-column flex-grow-1 gap-1" Elevation="0">
+                            @foreach (var effectInfo in Node.EffectDetails)
+                            {
+                                <MudText class="ml-1 mr-1" Typo="Typo.caption">@effectInfo.Name. : @effectInfo.Value%</MudText>
+                            }
+                        </MudPaper>
+                    </TooltipContent>
+                </MudTooltip>
+            }
+        </CardHeaderActions>
+    </MudCardHeader>
 
-
+    <MudCardContent Class="d-flex pa-1 pr-2 justify-space-between">
+        <div Class="d-flex justify-start">
+            @if (Node != null && Node.ConnectedUsers != null && Node.ConnectedUsers.FirstOrDefault() != null)
+            {
+                <MudTooltip Typo="Typo.caption" Arrow="true" Placement="Placement.Bottom">
+                    <ChildContent>
+                        <MudIcon Icon="@Icons.Material.Filled.Group" Color=Color.Default Size="Size.Small" />
+                    </ChildContent>
+                    <TooltipContent>
+                        <MudPaper Class="d-flex flex-column flex-grow-1 gap-1" Elevation="0">
+                            @foreach (var user in @Node.ConnectedUsers)
+                            {
+                                <MudText class="ml-1 mr-1" Typo="Typo.caption">@user</MudText>
+                            }
+                        </MudPaper>
+                    </TooltipContent>
+                </MudTooltip>
+            }
+            else
+            {
+                <MudIcon Icon="@Icons.Material.Filled.Group" Color=Color.Transparent Size="Size.Small" />
+            }
+            <MudText Class="align-self-stretch ml-1 mt-1" Typo="Typo.caption">@Node?.ConnectedUsers.FirstOrDefault()</MudText>
+        </div>
+        <div Class="d-flex justify-end">
+            @if (Node != null && Node.Statics != null && Node?.Statics.Count() > 0)
+            {
+                @foreach (var item in Node.Statics)
+                {
+                    <MudText Class="align-self-stretch mt-1 ml-1" Typo="Typo.body2" Style="@($"color:{WHColorHelper.GetSystemTypeColor(@item.EveSystemDestinationType)};")">@item.EveSystemDestinationType.ToString()</MudText>
+                }
+            }
+        </div>
+    </MudCardContent>
+</MudCard>
 

--- a/WHMapper/Pages/Mapper/Overview.cs
+++ b/WHMapper/Pages/Mapper/Overview.cs
@@ -26,6 +26,9 @@ using WHMapper.Services.WHSignature;
 using WHMapper.Services.EveMapper;
 using Blazor.Diagrams.Core.Behaviors;
 using WHMapper.Models.DTO.EveMapper.Enums;
+using Blazor.Diagrams.Core;
+using MudBlazor.Utilities;
+using System.Xml.Linq;
 
 namespace WHMapper.Pages.Mapper
 {
@@ -34,6 +37,12 @@ namespace WHMapper.Pages.Mapper
     [Authorize(Policy = "Access")]
     public partial class Overview : ComponentBase, IAsyncDisposable
     {
+        private const string MENU_LOCK_SYSTEM_VALUE = "Lock";
+        private const string MENU_UNLOCK_SYSTEM_VALUE = "Unlock";
+
+        private string _menu_lock_value = MENU_LOCK_SYSTEM_VALUE;
+        private string _menu_lock_icon_value = Icons.Material.Sharp.Lock;
+
         protected BlazorDiagram Diagram { get; private set; } = null!;
         private MudMenu ClickRightMenu { get; set; } = null!;
         private WHMapper.Pages.Mapper.Signatures.Overview WHSignaturesView { get; set; } = null!;
@@ -46,16 +55,16 @@ namespace WHMapper.Pages.Mapper
         private int _currentWHSystemId = 0;
         private EveSystemNodeModel? _selectedSystemNode = null;
         private EveSystemLinkModel? _selectedSystemLink = null;
-        
+
         private ICollection<EveSystemNodeModel>? _selectedSystemNodes = null;
         private ICollection<EveSystemLinkModel>? _selectedSystemLinks = null;
 
-        private PeriodicTimer _timer=null!;
-        private CancellationTokenSource _cts= null!;
+        private PeriodicTimer _timer = null!;
+        private CancellationTokenSource _cts = null!;
 
         private SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
 
-        private HubConnection _hubConnection=null!;
+        private HubConnection _hubConnection = null!;
 
         [Inject]
         IAuthorizationService AuthorizationService { get; set; } = null!;
@@ -90,7 +99,7 @@ namespace WHMapper.Pages.Mapper
         [Inject]
         public ISnackbar Snackbar { get; set; } = null!;
 
-        [Inject] IWHSignatureHelper SignatureHelper { get; set; } = null!; 
+        [Inject] IWHSignatureHelper SignatureHelper { get; set; } = null!;
 
         [Inject]
         public NavigationManager Navigation { get; set; } = null!;
@@ -108,7 +117,7 @@ namespace WHMapper.Pages.Mapper
 
         private IEnumerable<WHMap> WHMaps { get; set; } = new List<WHMap>();
         private WHMap _selectedWHMap = null!;
-        
+
         private int _selectedWHMapIndex = 0;
         private int SelectedWHMapIndex
         {
@@ -121,7 +130,7 @@ namespace WHMapper.Pages.Mapper
                 if (_selectedWHMapIndex != value)
                 {
                     _selectedWHMapIndex = value;
-                    if(WHMaps!=null)
+                    if (WHMaps != null)
                         _selectedWHMap = WHMaps.ElementAtOrDefault(value);
                 }
             }
@@ -147,7 +156,7 @@ namespace WHMapper.Pages.Mapper
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
-            if(firstRender)
+            if (firstRender)
             {
                 var user = (await AuthenticationStateTask).User;
 
@@ -199,7 +208,7 @@ namespace WHMapper.Pages.Mapper
                         {
                             Snackbar?.Add($"{user} are connected", Severity.Info);
                         }
-                        catch(Exception ex)
+                        catch (Exception ex)
                         {
                             Logger.LogError(ex, "On NotifyUserConnected error");
                         }
@@ -293,7 +302,7 @@ namespace WHMapper.Pages.Mapper
                     {
                         try
                         {
-                            if (DbWHMaps!=null && _selectedWHMap!=null && wormholeId > 0 && _selectedWHMap?.Id== mapId)
+                            if (DbWHMaps != null && _selectedWHMap != null && wormholeId > 0 && _selectedWHMap?.Id == mapId)
                             {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
                                 var systemNodeToDelete = Diagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).IdWH == wormholeId);
@@ -327,7 +336,7 @@ namespace WHMapper.Pages.Mapper
                     {
                         try
                         {
-                            if (DbWHMaps != null && linKId > 0 && _selectedWHMap!=null && _selectedWHMap?.Id== mapId )
+                            if (DbWHMaps != null && linKId > 0 && _selectedWHMap != null && _selectedWHMap?.Id == mapId)
                             {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
                                 var link = _selectedWHMap.WHSystemLinks.Where(x => x.Id == linKId).SingleOrDefault();
@@ -350,7 +359,7 @@ namespace WHMapper.Pages.Mapper
                         try
                         {
                             if (DbWHMaps != null && linKId > 0 && _selectedWHMap != null && _selectedWHMap?.Id == mapId)
-                            { 
+                            {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
 
                                 var linkToDel = Diagram?.Links?.FirstOrDefault(x => ((EveSystemLinkModel)x).Id == linKId);
@@ -384,7 +393,7 @@ namespace WHMapper.Pages.Mapper
                         }
                     });
 
-                    _hubConnection.On<string, int, int, bool, SystemLinkSize, SystemLinkMassStatus>("NotifyLinkChanged",async (user, mapId, linkId, eol, size, mass) =>
+                    _hubConnection.On<string, int, int, bool, SystemLinkSize, SystemLinkMassStatus>("NotifyLinkChanged", async (user, mapId, linkId, eol, size, mass) =>
                     {
                         try
                         {
@@ -407,7 +416,7 @@ namespace WHMapper.Pages.Mapper
                         }
                     });
 
-                    _hubConnection.On<string, int, int,bool>("NotifyWormholeNameExtensionChanged", async (user, mapId, wormholeId,increment) =>
+                    _hubConnection.On<string, int, int, bool>("NotifyWormholeNameExtensionChanged", async (user, mapId, wormholeId, increment) =>
                     {
                         try
                         {
@@ -462,7 +471,7 @@ namespace WHMapper.Pages.Mapper
                             {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
                                 EveSystemNodeModel whChangeLock = (EveSystemNodeModel)Diagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).IdWH == wormholeId);
-                                if(whChangeLock!=null)
+                                if (whChangeLock != null)
                                 {
                                     whChangeLock.Locked = locked;
                                     whChangeLock.Refresh();
@@ -482,7 +491,7 @@ namespace WHMapper.Pages.Mapper
                 }
                 return false;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Logger.LogError(ex, "InitNotificationHub error");
                 return false;
@@ -498,11 +507,11 @@ namespace WHMapper.Pages.Mapper
             }
         }
 
-        private async Task NotifyWormoleAdded(int mapId,int wormholeId)
+        private async Task NotifyWormoleAdded(int mapId, int wormholeId)
         {
             if (_hubConnection is not null)
             {
-                await _hubConnection.SendAsync("SendWormholeAdded", mapId,wormholeId);
+                await _hubConnection.SendAsync("SendWormholeAdded", mapId, wormholeId);
             }
         }
 
@@ -510,11 +519,11 @@ namespace WHMapper.Pages.Mapper
         {
             if (_hubConnection is not null)
             {
-                await _hubConnection.SendAsync("SendWormholeRemoved", mapId,wormholeId);
+                await _hubConnection.SendAsync("SendWormholeRemoved", mapId, wormholeId);
             }
         }
 
-        private async Task NotifyLinkAdded(int mapId,int linkId)
+        private async Task NotifyLinkAdded(int mapId, int linkId)
         {
             if (_hubConnection is not null)
             {
@@ -530,7 +539,7 @@ namespace WHMapper.Pages.Mapper
             }
         }
 
-        private async Task NotifyWormholeMoved(int mapId, int wormholeId,double posX,double posY)
+        private async Task NotifyWormholeMoved(int mapId, int wormholeId, double posX, double posY)
         {
             if (_hubConnection is not null)
             {
@@ -538,7 +547,7 @@ namespace WHMapper.Pages.Mapper
             }
         }
 
-        private async Task NotifyLinkChanged(int mapId,int linkId, bool eol, SystemLinkSize size, SystemLinkMassStatus mass)
+        private async Task NotifyLinkChanged(int mapId, int linkId, bool eol, SystemLinkSize size, SystemLinkMassStatus mass)
         {
             if (_hubConnection is not null)
             {
@@ -546,7 +555,7 @@ namespace WHMapper.Pages.Mapper
             }
         }
 
-        private async Task NotifyWormholeNameExtensionChanged(int mapId, int wormholeId,bool increment)
+        private async Task NotifyWormholeNameExtensionChanged(int mapId, int wormholeId, bool increment)
         {
             if (_hubConnection is not null)
             {
@@ -593,13 +602,14 @@ namespace WHMapper.Pages.Mapper
                     Diagram.Options.Zoom.Inverse = false;
                     Diagram.Options.Links.EnableSnapping = false;
                     Diagram.Options.AllowMultiSelection = true;
+                    
                     Diagram.RegisterComponent<EveSystemNodeModel, EveSystemNode>();
                     Diagram.RegisterComponent<EveSystemLinkModel, EveSystemLink>();
                 }
 
                 return true;
-            }            
-            catch(Exception ex)
+            }
+            catch (Exception ex)
             {
                 Logger.LogError(ex, "Init Diagram Error");
                 return false;
@@ -624,9 +634,17 @@ namespace WHMapper.Pages.Mapper
                     _selectedSystemLink = null;
 
                     if (((EveSystemNodeModel)item).Selected)
+                    {
                         _selectedSystemNode = (EveSystemNodeModel)item;
+                        Diagram.SendToFront(_selectedSystemNode);
+                    }
                     else
+                    {
+                        if (_selectedSystemNode != null)
+                            Diagram.SendToBack(_selectedSystemNode);
+
                         _selectedSystemNode = null;
+                    }
 
                     StateHasChanged();
                     return;
@@ -642,7 +660,7 @@ namespace WHMapper.Pages.Mapper
                     else
                         _selectedSystemLink = null;
 
-                    
+
                     StateHasChanged();
                     return;
                 }
@@ -691,8 +709,8 @@ namespace WHMapper.Pages.Mapper
         private async Task<bool> OnLinkSystemKeyPressed(Blazor.Diagrams.Core.Events.KeyboardEventArgs eventArgs)
         {
             if (eventArgs.Code == "KeyL" && _selectedWHMap != null && _selectedSystemNodes != null && _selectedSystemNodes.Count() == 2)
-            { 
-            
+            {
+
                 if (IsLinkExist(_selectedSystemNodes.ElementAt(0), _selectedSystemNodes.ElementAt(1)))
                 {
                     Snackbar.Add("Nodes are already linked", Severity.Warning);
@@ -709,7 +727,7 @@ namespace WHMapper.Pages.Mapper
                     else
                         return true;
                 }
-               
+
             }
             return false;
 
@@ -771,7 +789,7 @@ namespace WHMapper.Pages.Mapper
                                 }
                                 else
                                 {
-                                    Snackbar?.Add(string.Format("{0} wormhole is locked.You can't remove it.",node.Name), Severity.Warning);
+                                    Snackbar?.Add(string.Format("{0} wormhole is locked.You can't remove it.", node.Name), Severity.Warning);
                                 }
 
                             }
@@ -820,6 +838,8 @@ namespace WHMapper.Pages.Mapper
 
         #endregion
 
+
+
         private async Task OnDiagramPointerUp(Blazor.Diagrams.Core.Models.Base.Model? item, Blazor.Diagrams.Core.Events.PointerEventArgs eventArgs)
         {
             if (item == null)
@@ -863,7 +883,7 @@ namespace WHMapper.Pages.Mapper
                 }
 
             }
-            
+
         }
 
         private async Task<bool> Restore()
@@ -891,7 +911,7 @@ namespace WHMapper.Pages.Mapper
                 }
 
 
-                
+
 
                 if (_selectedWHMap != null && _selectedWHMap.WHSystems.Count > 0)
                 {
@@ -905,9 +925,9 @@ namespace WHMapper.Pages.Mapper
 
                 }
 
-                if (_selectedWHMap!=null && _selectedWHMap.WHSystemLinks!=null && _selectedWHMap.WHSystemLinks.Count > 0)
+                if (_selectedWHMap != null && _selectedWHMap.WHSystemLinks != null && _selectedWHMap.WHSystemLinks.Count > 0)
                 {
-                    
+
                     foreach (WHSystemLink dbWHSysLink in _selectedWHMap.WHSystemLinks)
                     {
                         var whFrom = await DbWHSystems.GetById(dbWHSysLink.IdWHSystemFrom);
@@ -922,7 +942,7 @@ namespace WHMapper.Pages.Mapper
                         else
                         {
                             Logger.LogWarning("Bad Link,Auto remove");
-                            if(await DbWHSystemLinks.DeleteById(dbWHSysLink.Id))
+                            if (await DbWHSystemLinks.DeleteById(dbWHSysLink.Id))
                             {
                                 _selectedWHMap.WHSystemLinks.Remove(dbWHSysLink);
                             }
@@ -932,16 +952,16 @@ namespace WHMapper.Pages.Mapper
                 Logger.LogInformation("Restore Mapper Success");
                 StateHasChanged();
                 return true;
-                
+
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Logger.LogError(ex, "Mapper Restore");
                 return false;
             }
         }
 
-        private async Task HandleTimerAsync()   
+        private async Task HandleTimerAsync()
         {
             _currentLocation = null;
             _currentSystemNode = null;
@@ -963,13 +983,13 @@ namespace WHMapper.Pages.Mapper
                         _cts.Cancel();//todo redirect to logout
                 }
             }
-            catch(OperationCanceledException oce)
+            catch (OperationCanceledException oce)
             {
                 Logger.LogInformation(oce, "Cancel operation");
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex,"Polling error");
+                Logger.LogError(ex, "Polling error");
             }
         }
 
@@ -983,7 +1003,7 @@ namespace WHMapper.Pages.Mapper
                     return false;
                 }
 
-                if(map.WHSystems.Count>0 && map.WHSystems.FirstOrDefault(x=>x.Id==node.IdWH)==null)
+                if (map.WHSystems.Count > 0 && map.WHSystems.FirstOrDefault(x => x.Id == node.IdWH) == null)
                 {
                     Logger.LogError("DeletedNodeOnMap map doesn't contain this node");
                     return false;
@@ -992,14 +1012,14 @@ namespace WHMapper.Pages.Mapper
                 if (await DbWHSystems.DeleteById(node.IdWH) != null)
                 {
                     var whSystemToDelete = map.WHSystems.FirstOrDefault(x => x.Id == node.IdWH);
-                    if(whSystemToDelete!=null)
+                    if (whSystemToDelete != null)
                         map.WHSystems.Remove(whSystemToDelete);
 
                     //db link will be automatically delete via db foreignkey cascade
                     var whSystemLinksToDetele = map.WHSystemLinks.Where(x => x.IdWHSystemFrom == node.IdWH || x.IdWHSystemTo == node.IdWH);
-                    foreach(var linkToDelete in whSystemLinksToDetele)
+                    foreach (var linkToDelete in whSystemLinksToDetele)
                         map.WHSystemLinks.Remove(linkToDelete);
-                    
+
                     await NotifyWormholeRemoved(map.Id, node.IdWH);
                     return true;
                 }
@@ -1023,7 +1043,7 @@ namespace WHMapper.Pages.Mapper
                     return false;
                 }
 
-                if(await DbWHSystemLinks.DeleteById(link.Id))
+                if (await DbWHSystemLinks.DeleteById(link.Id))
                 {
                     var whSystemLinkToDelete = map.WHSystemLinks.FirstOrDefault(x => x.Id == link.Id);
                     if (whSystemLinkToDelete != null)
@@ -1043,7 +1063,7 @@ namespace WHMapper.Pages.Mapper
 
         }
 
-        private async Task<bool> IncrementOrDecrementNodeExtensionNameOnMap(WHMap map, EveSystemNodeModel node,bool increment)
+        private async Task<bool> IncrementOrDecrementNodeExtensionNameOnMap(WHMap map, EveSystemNodeModel node, bool increment)
         {
             try
             {
@@ -1085,7 +1105,7 @@ namespace WHMapper.Pages.Mapper
                 return false;
             }
         }
-    
+
         private async Task<bool> CreateLink(WHMap map, EveSystemNodeModel src, EveSystemNodeModel target)
         {
             try
@@ -1108,7 +1128,7 @@ namespace WHMapper.Pages.Mapper
                 }
                 return false;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Logger.LogError(ex, "Create link error");
                 return false;
@@ -1156,13 +1176,13 @@ namespace WHMapper.Pages.Mapper
                 return false;
 
 
-            if((src != null && src.Stargates==null) || dst.Stargates==null)
+            if ((src != null && src.Stargates == null) || dst.Stargates == null)
                 return true;
             else
             {
                 int[]? startgatesToCheck = null;
                 int systemTarget = -1;
-                if (src!=null && src.Stargates.Length <= dst.Stargates.Length)
+                if (src != null && src.Stargates.Length <= dst.Stargates.Length)
                 {
                     startgatesToCheck = dst.Stargates;
                     systemTarget = src.SystemId;
@@ -1181,14 +1201,14 @@ namespace WHMapper.Pages.Mapper
                         return false;
                 }
 
-                 return true;
+                return true;
             }
         }
 
         private async Task AutoMapper()
         {
             EveSystemNodeModel? previousSystem = null;
-            SolarSystem?  previousSolarSystem = null;
+            SolarSystem? previousSolarSystem = null;
             WHSystem? newWHSystem = null;
             double defaultNewSystemPosX = 0;
             double defaultNewSystemPosY = 0;
@@ -1196,8 +1216,8 @@ namespace WHMapper.Pages.Mapper
             try
             {
                 EveLocation el = await EveServices.LocationServices.GetLocation();
-                
-                if (el != null && (_currentLocation == null || _currentLocation.SolarSystemId != el.SolarSystemId) )
+
+                if (el != null && (_currentLocation == null || _currentLocation.SolarSystemId != el.SolarSystemId))
                 {
                     previousSystem = _currentSystemNode;
                     previousSolarSystem = _currentSolarSystem;
@@ -1210,16 +1230,16 @@ namespace WHMapper.Pages.Mapper
                         //determine position on map. depends of previous system
                         if (previousSystem != null)
                         {
-                            defaultNewSystemPosX  = (double)previousSystem.Position.X + previousSystem.Size.Width + 10;
+                            defaultNewSystemPosX = (double)previousSystem.Position.X + previousSystem.Size.Width + 10;
                             defaultNewSystemPosY = (double)previousSystem.Position.Y + previousSystem.Size.Height + 10;
                         }
 
                         //determine if source have same system link and get next unique ident
-                        if(previousSystem != null && await IsRouteViaWH(previousSolarSystem, _currentSolarSystem))
+                        if (previousSystem != null && await IsRouteViaWH(previousSolarSystem, _currentSolarSystem))
                         {
                             //test is WH
 
-                            if(!MapperServices.IsWorhmole(_currentSolarSystem.Name))
+                            if (!MapperServices.IsWorhmole(_currentSolarSystem.Name))
                             {
                                 newWHSystem = await DbWHSystems.Create(new WHSystem(_selectedWHMap.Id, _currentSolarSystem.SystemId, _currentSolarSystem.Name, _currentSolarSystem.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
                             }
@@ -1228,7 +1248,7 @@ namespace WHMapper.Pages.Mapper
                                 //get whClass an determine if another connection to another wh with same class exist from previous system. Increment extension value in that case
                                 EveSystemType whClass = await MapperServices.GetWHClass(_currentSolarSystem);
 
-                                int nbSameWHClassLink = Diagram.Links.Where(x => ((EveSystemNodeModel)x.Target.Model).SystemType==whClass && ((EveSystemNodeModel)x.Source.Model).IdWH == previousSystem.IdWH).Count();
+                                int nbSameWHClassLink = Diagram.Links.Where(x => ((EveSystemNodeModel)x.Target.Model).SystemType == whClass && ((EveSystemNodeModel)x.Source.Model).IdWH == previousSystem.IdWH).Count();
 
                                 if (nbSameWHClassLink > 0)
                                 {
@@ -1240,10 +1260,10 @@ namespace WHMapper.Pages.Mapper
                             }
                         }
                         else
-                            newWHSystem = await DbWHSystems.Create(new WHSystem(_selectedWHMap.Id,_currentSolarSystem.SystemId,_currentSolarSystem.Name, _currentSolarSystem.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
-                        
+                            newWHSystem = await DbWHSystems.Create(new WHSystem(_selectedWHMap.Id, _currentSolarSystem.SystemId, _currentSolarSystem.Name, _currentSolarSystem.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
 
-                        if (newWHSystem!=null)
+
+                        if (newWHSystem != null)
                         {
                             var newSystemNode = await MapperServices.DefineEveSystemNodeModel(newWHSystem);
                             newSystemNode.OnLocked += OnWHSystemNodeLocked;
@@ -1256,7 +1276,7 @@ namespace WHMapper.Pages.Mapper
 
                             if (previousSystem != null)
                             {
-                                if(!await CreateLink(_selectedWHMap, previousSystem, newSystemNode))
+                                if (!await CreateLink(_selectedWHMap, previousSystem, newSystemNode))
                                 {
                                     Logger.LogError("Add Wormhole Link db error");
                                     Snackbar?.Add("Add Wormhole Link db error", Severity.Error);
@@ -1285,7 +1305,7 @@ namespace WHMapper.Pages.Mapper
                             await previousSystem.RemoveConnectedUser(_userName);
                             previousSystem.Refresh();
                         }
-                            
+
                         _currentSystemNode = (EveSystemNodeModel)Diagram.Nodes.FirstOrDefault(x => string.Equals(x.Title, _currentSolarSystem.Name, StringComparison.OrdinalIgnoreCase));
                         await _currentSystemNode.AddConnectedUser(_userName);
                         _currentSystemNode.Refresh();
@@ -1297,7 +1317,7 @@ namespace WHMapper.Pages.Mapper
 
                         if (previousSystem != null)
                         {
-                            if(IsLinkExist(previousSystem, _currentSystemNode)==false)
+                            if (IsLinkExist(previousSystem, _currentSystemNode) == false)
                             {
                                 if (!await CreateLink(_selectedWHMap, previousSystem, _currentSystemNode))
                                 {
@@ -1305,11 +1325,11 @@ namespace WHMapper.Pages.Mapper
                                     Snackbar?.Add("Add Wormhole Link db error", Severity.Error);
                                 }
                             }
-                        } 
+                        }
                     }
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Logger.LogError(ex, "Auto mapper error");
             }
@@ -1347,6 +1367,89 @@ namespace WHMapper.Pages.Mapper
         }
 
         #region Menu Actions
+
+        private void OnMenuOpen(MouseEventArgs args)
+        {
+            if (_selectedSystemNode != null || _selectedSystemLink!=null)
+            {
+                ClickRightMenu.PopoverStyle = $"margin-top: {args?.ClientY.ToPx()}; margin-left: {args?.ClientX.ToPx()};";
+            }
+        }
+
+
+        private async Task<bool> SetSelectedSystemDestinationWaypoint()
+        {
+            try
+            {
+                if (_selectedSystemNode == null)
+                    return false;
+
+                if (_selectedSystemNode.Selected)
+                {
+                    var res = await EveServices.UserInterfaceServices.SetWaypoint(_selectedSystemNode.SolarSystemId, false, true);
+                    return true;
+
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Set destination waypoint error");
+                return false;
+            }
+        }
+
+        private async Task<bool> ToggleSystemLock()
+        {
+            try
+            {
+                if (_selectedSystemNode == null)
+                    return false;
+
+                var whSystem = await DbWHSystems.GetById(_selectedSystemNode.IdWH);
+                if (whSystem != null && whSystem.Id == _selectedSystemNode.IdWH)
+                {
+                    whSystem.Locked = !whSystem.Locked;
+                    whSystem = await DbWHSystems.Update(whSystem.Id, whSystem);
+                    if (whSystem == null)
+                    {
+                        Logger.LogError("Update lock system status error");
+                        return false;
+                    }
+
+                    _selectedSystemNode.Locked = whSystem.Locked;
+
+                    if (_selectedSystemNode.Locked)
+                    {
+                        _menu_lock_value = MENU_UNLOCK_SYSTEM_VALUE;
+                        _menu_lock_icon_value = Icons.Material.Sharp.LockOpen;
+                    }
+                    else
+                    {
+                        _menu_lock_value = MENU_LOCK_SYSTEM_VALUE;
+                        _menu_lock_icon_value = Icons.Material.Sharp.Lock;
+                    }
+                    
+                    _selectedSystemNode.Refresh();
+                    StateHasChanged();
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+
+
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Toggle destination waypoint error");
+                return false;
+            }
+
+        }
+
 
         /// <summary>
         /// Menu intercep paste

--- a/WHMapper/Pages/Mapper/Overview.razor
+++ b/WHMapper/Pages/Mapper/Overview.razor
@@ -11,7 +11,7 @@
 
 
 <MudPaper Class="@(_loading ? "invisible" : "visible ma-2")" Outlined="true" Square="true" Height="60vh" MinHeight="60vh">
-    <MudMenu @ref="ClickRightMenu" PositionAtCursor="true" ActivationEvent="@MouseEvent.RightClick" Dense="true" @oncustompaste="HandleCustomPaste" style="height: 100%; width: 100%;">
+    <MudMenu @ref="ClickRightMenu" PositionAtCursor="true" ActivationEvent="@MouseEvent.RightClick" Dense="true" @oncustompaste="HandleCustomPaste" style="height: 100%; width: 100%;" @oncontextmenu="OnMenuOpen">
         <ActivatorContent>
             @if (!FeatureFlag.DISABLE_MULTI_MAP())
             {
@@ -78,6 +78,11 @@
                         </ChildContent>
                     </MudMenu>
                 </div>
+            }
+            @if (_selectedSystemNode != null)
+            {
+                <MudMenuItem Icon="@Icons.Material.Sharp.FlagCircle" Size="Size.Small" OnClick="@(() => SetSelectedSystemDestinationWaypoint())">Set Destination</MudMenuItem>
+                <MudMenuItem Icon="@_menu_lock_icon_value" Size="Size.Small" OnClick="@(() => ToggleSystemLock())">@_menu_lock_value</MudMenuItem>
             }
 
         </ChildContent>

--- a/WHMapper/Pages/Mapper/Signatures/Overview.razor
+++ b/WHMapper/Pages/Mapper/Signatures/Overview.razor
@@ -2,7 +2,7 @@
 @using WHMapper.Models.DTO.EveMapper.Enums
 
 
-<MudTable Class="@(CurrentSystemNodeId == null ? "invisible ma-2" : "visible ma-2")" Outlined="true" Items="@Signatures" Dense=true Hover=false Bordered=true Striped=true SortLabel="Sort By" Height="30vh" style="width: 100%;" Virtualize="true" Loading="@(Signatures==null)" LoadingProgressColor="Color.Info"
+<MudTable Class="@(CurrentSystemNodeId == null ? "invisible ma-2" : "visible ma-2")" AllowUnsorted="false" Outlined="true" Items="@Signatures" Dense=true Hover=false Bordered=true Striped=true SortLabel="Sort By" Height="30vh" style="width: 100%;" Virtualize="true" Loading="@(Signatures==null)" LoadingProgressColor="Color.Info"
           CommitEditTooltip="Commit" ApplyButtonPosition="TableApplyButtonPosition.End" CanCancelEdit="true" IsEditRowSwitchingBlocked="false" SelectedItem="_selectedSignature"
           RowEditPreview="BackupSingature" RowEditCancel="ResetSingatureToOriginalValues" RowEditCommit="SignatiureHasBeenCommitted" CancelEditIcon="@Icons.Material.Filled.Cancel" CommitEditIcon="@Icons.Material.Filled.Edit" FixedHeader="true">
 

--- a/WHMapper/Pages/Mapper/SystemInfos/Overview.razor
+++ b/WHMapper/Pages/Mapper/SystemInfos/Overview.razor
@@ -50,7 +50,7 @@
         </MudItem>
         <MudItem xs="0">
             <MudText Typo="Typo.body2" Class="d-inline-flex">@_effect</MudText>
-            @if (CurrentSystemNode?.Effect != WHMapper.Models.DTO.EveMapper.Enums.WHEffect.None)
+            @if (CurrentSystemNode != null && CurrentSystemNode?.Effect != WHMapper.Models.DTO.EveMapper.Enums.WHEffect.None)
             {
                 <MudTooltip Text="Arrow Right" Arrow="true" Placement="Placement.Bottom">
                     <ChildContent>
@@ -60,7 +60,7 @@
                         <MudPaper Class="d-flex flex-column flex-grow-1 gap-1" Elevation="0">
                             @if (CurrentSystemNode != null && CurrentSystemNode.EffectDetails != null)
                             {
-                                foreach (var effectInfo in CurrentSystemNode?.EffectDetails)
+                                foreach (var effectInfo in CurrentSystemNode.EffectDetails)
                                 {
                                     <MudText class="ml-1 mr-1" Typo="Typo.caption">@effectInfo.Name : @effectInfo.Value%</MudText>
                                 }

--- a/WHMapper/WHMapper.csproj
+++ b/WHMapper/WHMapper.csproj
@@ -81,8 +81,8 @@
     <PackageReference Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.0" />
     <PackageReference Include="Z.Blazor.Diagrams.Core" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.11" />
-    <PackageReference Include="Npgsql" Version="7.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
+    <PackageReference Include="Npgsql" Version="7.0.6" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -92,8 +92,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="7.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="7.0.11" />
-    <PackageReference Include="YamlDotNet" Version="13.3.1" />
-    <PackageReference Include="MudBlazor" Version="6.9.0" />
+    <PackageReference Include="YamlDotNet" Version="13.4.0" />
+    <PackageReference Include="MudBlazor" Version="6.10.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Data\" />


### PR DESCRIPTION
* Multifixes (#144)

* #141 : fixed Click on a header to sort the table by that column, then click to cycle through sorting directions. By default, sorting directions are ascending, descending and unsorted; if you want to cycle through ascending and descending only, you need to specify the <AllowUnsorted> parameter of the <MudTable>. Sorting can be allowed and disallowed on the column level with the property Enabled.

* #142 : fixed Using SendToFront and SendToBack

* #140 : fixed (via workaround)
bug is already open here : https://github.com/Blazor-Diagrams/Blazor.Diagrams/issues/323

* update missing package

* Update Overview.razor (#145)

* Update Overview.razor (#146)