### PR TITLE
ADD multi plaform build detection for dotnet/sdk

### DIFF
--- a/src/WHMapper/Dockerfile
+++ b/src/WHMapper/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /src
 COPY ["WHMapper.csproj", "."]
 RUN dotnet restore "WHMapper.csproj"


### PR DESCRIPTION
ADD multi plaform build detection for dotnet/sdk. 

Use docker buildx: 
Create build container: `docker buildx create --name container-map --driver=docker-container`
Build/tag/manifest and push cmd: `docker buildx build --tag <repo>/eve-whmapper:latest --platform linux/arm/v8,linux/amd64 --builder <container-name> --push .`

platforms: 
- linux/amd64: Linux 64
- linux/arm/v8: Raspberry