### PR TITLE
"Add caching for EveEntity retrieval and reduce API requests"

### DIFF
--- a/src/WHMapper.Tests/Models/Graph/EveEntityModelTest.cs
+++ b/src/WHMapper.Tests/Models/Graph/EveEntityModelTest.cs
@@ -66,5 +66,40 @@ namespace WHMapper.Tests.Models.Graph
 
             return Task.CompletedTask;
         }
+
+/*
+        [Fact]
+        public Task ShipEntity_Model_Test()
+        {
+            var fake_eveapi_type = new Type();
+            fake_eveapi_type.Name="Test Ship";
+
+            var ship_entity = new ShipEntity(1,fake_eveapi_type);
+            Assert.NotNull(ship_entity);
+            Assert.Equal(1,ship_entity.Id);
+            Assert.Equal("Test Ship",ship_entity.Name);
+
+            ship_entity = new ShipEntity(1,"Test Ship");
+            Assert.NotNull(ship_entity);
+            Assert.Equal(1,ship_entity.Id);
+            Assert.Equal("Test Ship",ship_entity.Name);
+            Assert.Equal(EveEntityEnums.Ship,ship_entity.EntityType);
+
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public Task SystemEntity_Model_Test()
+        {
+            
+
+            var system_entity = new SystemEntity(1,"Test System");
+            Assert.NotNull(system_entity);
+            Assert.Equal(1,system_entity.Id);
+            Assert.Equal("Test System",system_entity.Name);
+            Assert.Equal(EveEntityEnums.System,system_entity.EntityType);
+
+            return Task.CompletedTask;
+        }*/
     }
 }

--- a/src/WHMapper.Tests/Services/EveOnlineAPI/PublicEveOnlineAPITest.cs
+++ b/src/WHMapper.Tests/Services/EveOnlineAPI/PublicEveOnlineAPITest.cs
@@ -128,7 +128,7 @@ public class PublicEveOnlineAPITest
         Assert.Equal(SOLAR_SYSTEM_JITA_NAME, jita.Name);
         Assert.NotNull(jita.Stargates);
 
-        var jita_constellation = await _eveUniverseApi.GetContellation(jita.ConstellationId);
+        var jita_constellation = await _eveUniverseApi.GetConstellation(jita.ConstellationId);
         Assert.NotNull(jita_constellation);
         Assert.Equal(CONSTELLATION_NAME, jita_constellation.Name);
 

--- a/src/WHMapper.Tests/WHHelper/EveWHMapperEntityTest.cs
+++ b/src/WHMapper.Tests/WHHelper/EveWHMapperEntityTest.cs
@@ -1,0 +1,403 @@
+
+using System.Diagnostics;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using WHMapper.Models.DTO;
+using WHMapper.Services.Cache;
+using WHMapper.Services.EveAPI;
+using WHMapper.Services.EveMapper;
+using Xunit.Priority;
+
+namespace WHMapper.Tests.WHHelper;
+
+[Collection("10-WHMapperEntity")]
+[TestCaseOrderer(PriorityOrderer.Name, PriorityOrderer.Assembly)]
+
+public class EveWHMapperEntityTest
+{
+    private const int BAD_ID = -1;
+    private const int ALLIANCE_GOONS_ID = 1354830081;
+    private const string ALLIANCE_GOONS_NAME = "Goonswarm Federation";
+
+    private const int CORPORATION_GOONS_ID = 1344654522;
+    private const string CORPORATION_GOONS_NAME = "DJ's Retirement Fund";
+
+
+    private const int CHARACTER_GOONS_ID = 2113720458;
+    private const string CHARACTER_GOONS_NAME = "Sexy Gym Teacher";
+
+    private const int SHIP_RIFTER_ID = 587;
+    private const string SHIP_RIFTER_NAME = "Rifter";
+
+    private const int SYSTEM_JITA_ID = 30000142;
+    private const string SYSTEM_JITA_NAME = "Jita";
+
+    private const int CONSTELLATION_Kimotoro_ID = 20000020;
+    private const string CONSTELLATION_Kimotoro_NAME = "Kimotoro";
+
+    private const int REGION_THE_FORGE_ID = 10000002;
+    private const string REGION_THE_FORGE_NAME = "The Forge";
+
+    private const int STARGATE_JITA_TO_MAURASI_ID = 50001248;
+    private const string STARGATE_JITA_TO_MAURASI_NAME = "Maurasi";
+    
+
+    private const int GROUPE_WORMHOLE_ID = 988;
+
+    private readonly IEveMapperEntity _whMapperEntity;
+
+    
+
+
+    public EveWHMapperEntityTest()
+    {
+        //Create DB Context
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .AddEnvironmentVariables()
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddHttpClient();
+
+        services.AddStackExchangeRedisCache(option =>
+        {
+            option.Configuration = configuration.GetConnectionString("RedisConnection");
+            option.InstanceName = "WHMapper";
+        });
+
+        var provider = services.BuildServiceProvider();
+        if (provider != null)
+        {
+            var httpclientfactory = provider.GetService<IHttpClientFactory>();
+            IDistributedCache? _distriCache = provider.GetService<IDistributedCache>();
+
+            if(_distriCache != null && httpclientfactory!=null)
+            {
+
+                ILogger<EveMapperEntity> logger = new NullLogger<EveMapperEntity>();
+                ILogger<EveAPIServices> loggerAPI = new NullLogger<EveAPIServices>();
+                ILogger<CacheService> loggerCacheService = new NullLogger<CacheService>();
+
+                _whMapperEntity = new EveMapperEntity(logger, 
+                    new CacheService(loggerCacheService, _distriCache), 
+                    new EveAPIServices(loggerAPI, httpclientfactory, new TokenProvider(), null!));
+            }
+        }
+    }
+
+    [Fact, Priority(1)]
+    
+    private async Task Get_Character_Test()
+    {   
+        var clearing = await _whMapperEntity.ClearCharacterCache();
+        Assert.True(clearing);
+        
+        var character = await _whMapperEntity.GetCharacter(BAD_ID);
+        Assert.Null(character);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        character = await _whMapperEntity.GetCharacter(CHARACTER_GOONS_ID);
+        sw.Stop();
+        Assert.NotNull(character);
+        Assert.Equal(CHARACTER_GOONS_NAME, character.Name);
+        long without_cache = sw.ElapsedMilliseconds;
+        
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        character = await _whMapperEntity.GetCharacter(CHARACTER_GOONS_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(character);
+        Assert.Equal(CHARACTER_GOONS_NAME, character.Name);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearCharacterCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(2)]
+    private async Task Get_Corporation_Test()
+    {
+        var clearing = await _whMapperEntity.ClearCorporationCache();
+        Assert.True(clearing);
+
+        var corporation = await _whMapperEntity.GetCorporation(BAD_ID);
+        Assert.Null(corporation);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        corporation = await _whMapperEntity.GetCorporation(CORPORATION_GOONS_ID);
+        sw.Stop();
+        Assert.NotNull(corporation);
+        Assert.Equal(CORPORATION_GOONS_NAME, corporation.Name);
+        long without_cache = sw.ElapsedMilliseconds;
+
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        corporation = await _whMapperEntity.GetCorporation(CORPORATION_GOONS_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(corporation);
+        Assert.Equal(CORPORATION_GOONS_NAME, corporation.Name);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearCorporationCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(3)]
+    private async Task Get_Alliance_Test()
+    {
+        var clearing = await _whMapperEntity.ClearAllianceCache();
+        Assert.True(clearing);
+
+        var alliance = await _whMapperEntity.GetAlliance(BAD_ID);
+        Assert.Null(alliance);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        alliance = await _whMapperEntity.GetAlliance(ALLIANCE_GOONS_ID);
+        sw.Stop();
+        Assert.NotNull(alliance);
+        Assert.Equal(ALLIANCE_GOONS_NAME, alliance.Name);
+        long without_cache = sw.ElapsedMilliseconds;
+
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        alliance = await _whMapperEntity.GetAlliance(ALLIANCE_GOONS_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(alliance);
+        Assert.Equal(ALLIANCE_GOONS_NAME, alliance.Name);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearAllianceCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(4)]
+    private async Task Get_Ship_Test()
+    {
+        var clearing = await _whMapperEntity.ClearShipCache();
+        Assert.True(clearing);
+
+        var ship = await _whMapperEntity.GetShip(BAD_ID);
+        Assert.Null(ship);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        ship = await _whMapperEntity.GetShip(SHIP_RIFTER_ID);
+        sw.Stop();
+        Assert.NotNull(ship);
+        Assert.Equal(SHIP_RIFTER_NAME, ship.Name);
+        long without_cache = sw.ElapsedMilliseconds;
+
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        ship = await _whMapperEntity.GetShip(SHIP_RIFTER_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(ship);
+        Assert.Equal(SHIP_RIFTER_NAME, ship.Name);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearShipCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(5)]
+    private async Task Get_System_Test()
+    {
+        var clearing = await _whMapperEntity.ClearSystemCache();
+        Assert.True(clearing);
+
+        var system = await _whMapperEntity.GetSystem(BAD_ID);
+        Assert.Null(system);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        system = await _whMapperEntity.GetSystem(SYSTEM_JITA_ID);
+        sw.Stop();
+        Assert.NotNull(system);
+        Assert.Equal(SYSTEM_JITA_NAME, system.Name);
+        long without_cache = sw.ElapsedMilliseconds;
+
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        system = await _whMapperEntity.GetSystem(SYSTEM_JITA_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(system);
+        Assert.Equal(SYSTEM_JITA_NAME, system.Name);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearSystemCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(6)]
+    private async Task Get_Constellation_Test()
+    {
+        var clearing = await _whMapperEntity.ClearConstellationCache();
+        Assert.True(clearing);
+
+        var constellation = await _whMapperEntity.GetConstellation(BAD_ID);
+        Assert.Null(constellation);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        constellation = await _whMapperEntity.GetConstellation(CONSTELLATION_Kimotoro_ID);
+        sw.Stop();
+        Assert.NotNull(constellation);
+        Assert.Equal(CONSTELLATION_Kimotoro_NAME, constellation.Name);
+        long without_cache = sw.ElapsedMilliseconds;
+
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        constellation = await _whMapperEntity.GetConstellation(CONSTELLATION_Kimotoro_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(constellation);
+        Assert.Equal(CONSTELLATION_Kimotoro_NAME, constellation.Name);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearConstellationCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(7)]
+    private async Task Get_Region_Test()
+    {
+        var clearing = await _whMapperEntity.ClearRegionCache();
+        Assert.True(clearing);
+
+        var region = await _whMapperEntity.GetRegion(BAD_ID);
+        Assert.Null(region);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        region = await _whMapperEntity.GetRegion(REGION_THE_FORGE_ID);
+        sw.Stop();
+        Assert.NotNull(region);
+        Assert.Equal(REGION_THE_FORGE_NAME, region.Name);
+        long without_cache = sw.ElapsedMilliseconds;
+
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        region = await _whMapperEntity.GetRegion(REGION_THE_FORGE_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(region);
+        Assert.Equal(REGION_THE_FORGE_NAME, region.Name);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearRegionCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(8)]
+    private async Task Get_Stargate_Test()
+    {
+        var clearing = await _whMapperEntity.ClearStargateCache();
+        Assert.True(clearing);
+
+        var stargate = await _whMapperEntity.GetStargate(BAD_ID);
+        Assert.Null(stargate);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        stargate = await _whMapperEntity.GetStargate(STARGATE_JITA_TO_MAURASI_ID);
+        sw.Stop();
+        Assert.NotNull(stargate);
+        Assert.Equal(SYSTEM_JITA_ID, stargate.SourceId);
+        Assert.Contains(STARGATE_JITA_TO_MAURASI_NAME, stargate.Name);
+        long without_cache = sw.ElapsedMilliseconds;
+
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        stargate = await _whMapperEntity.GetStargate(STARGATE_JITA_TO_MAURASI_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(stargate);
+        Assert.Contains(STARGATE_JITA_TO_MAURASI_NAME, stargate.Name);
+        Assert.Equal(SYSTEM_JITA_ID, stargate.SourceId);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearStargateCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(9)]
+    private async Task Get_Group_Test()
+    {
+        var clearing = await _whMapperEntity.ClearGroupCache();
+        Assert.True(clearing);
+
+        var group = await _whMapperEntity.GetGroup(BAD_ID);
+        Assert.Null(group);
+
+        Stopwatch sw = new Stopwatch();
+        sw.Start();
+        group = await _whMapperEntity.GetGroup(GROUPE_WORMHOLE_ID);
+        sw.Stop();
+        Assert.NotNull(group);
+        Assert.NotEmpty(group.Types);
+        Assert.Equal(GROUPE_WORMHOLE_ID, group.Id);
+        long without_cache = sw.ElapsedMilliseconds;
+
+        //Check if cache is working
+        sw.Reset();
+        sw.Restart();
+        group = await _whMapperEntity.GetGroup(GROUPE_WORMHOLE_ID);
+        sw.Stop();
+        long with_cache = sw.ElapsedMilliseconds;
+        Assert.NotNull(group);
+        Assert.NotEmpty(group.Types);
+        Assert.Equal(GROUPE_WORMHOLE_ID, group.Id);
+        Assert.True(with_cache < without_cache);
+
+        clearing = await _whMapperEntity.ClearGroupCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(10)]
+    private async Task Get_Wormhole_Test()
+    {
+        var clearing = await _whMapperEntity.ClearWormholeCache();
+        Assert.True(clearing);
+
+        var wormhole = await _whMapperEntity.GetWormhole(BAD_ID);
+        Assert.Null(wormhole);
+
+        clearing = await _whMapperEntity.ClearWormholeCache();
+        Assert.True(clearing);
+    }
+
+    [Fact, Priority(11)]
+    private async Task Get_Sun_Test()
+    {
+        var clearing = await _whMapperEntity.ClearSunCache();
+        Assert.True(clearing);
+
+        var sun = await _whMapperEntity.GetSun(BAD_ID);
+        Assert.Null(sun);
+
+        clearing = await _whMapperEntity.ClearSunCache();
+        Assert.True(clearing);
+    }
+
+
+}

--- a/src/WHMapper.Tests/WHHelper/EveWHMapperHelperTest.cs
+++ b/src/WHMapper.Tests/WHHelper/EveWHMapperHelperTest.cs
@@ -12,6 +12,7 @@ using WHMapper.Models.DTO;
 using WHMapper.Models.DTO.EveAPI;
 using WHMapper.Models.DTO.EveAPI.Universe;
 using WHMapper.Models.DTO.EveMapper.Enums;
+using WHMapper.Models.DTO.EveMapper.EveEntity;
 using WHMapper.Repositories.WHNotes;
 using WHMapper.Services.Anoik;
 using WHMapper.Services.Cache;
@@ -35,6 +36,7 @@ public class EveWHMapperHelperTest
     private const string SOLAR_SYSTEM_JITA_NAME = "Jita";
     private const char SOLAR_SYSTEM_EXTENSION_NAME = 'B';
     private const string CONSTELLATION_JITA_NAME = "Kimotoro";
+    private const int CONSTALLATION_JITA_ID = 20000020;
     private const string REGION_JITA_NAME = "The Forge";
 
     private const string SOLAR_SYSTEM_AMAMAKE_NAME = "Amamake";
@@ -126,11 +128,12 @@ public class EveWHMapperHelperTest
         ILogger<EveAPIServices> loggerAPI = new NullLogger<EveAPIServices>();
         ILogger<WHNoteRepository> loggerWHNoteRepository = new NullLogger<WHNoteRepository>();
         ILogger<CacheService> loggerCacheService = new NullLogger<CacheService>();
+        ILogger<EveMapperEntity> loggerEveMapperEntity= new NullLogger<EveMapperEntity>();
 
         if(httpclientfactory!=null && _contextFactory != null && _distriCache != null)
         {
             _whEveMapper = new EveMapperHelper(loggerMapperHelper
-                , new EveAPIServices(loggerAPI, httpclientfactory, new TokenProvider(), null!)
+                ,new EveMapperEntity(loggerEveMapperEntity,new CacheService(loggerCacheService, _distriCache), new EveAPIServices(loggerAPI, httpclientfactory, new TokenProvider(), null!))
                 , new SDEServices(loggerSDE,new CacheService(loggerCacheService, _distriCache)),
                 new AnoikServices(loggerAnoik), new WHNoteRepository(loggerWHNoteRepository, _contextFactory));
         }
@@ -152,7 +155,7 @@ public class EveWHMapperHelperTest
     [Fact, Priority(2)]
     public async Task Get_Wormhole_Class()
     {
-        var result_C3_Bis= await _whEveMapper.GetWHClass(new ESISolarSystem(0, 31001123, SOLAR_SYSTEM_WH_NAME,null!,-1.0f,string.Empty,CONSTELLATION_WH_ID,null!,null!));
+        var result_C3_Bis= await _whEveMapper.GetWHClass(new SystemEntity(31001123, SOLAR_SYSTEM_WH_NAME,CONSTELLATION_WH_ID,-1.0f, new int[]{}));
         Assert.Equal(EveSystemType.C3, result_C3_Bis);
 
         var result_HS = await _whEveMapper.GetWHClass(REGION_JITA_NAME, "UNUSED", SOLAR_SYSTEM_JITA_NAME,1.0f);
@@ -226,6 +229,22 @@ public class EveWHMapperHelperTest
     {
         var result = await _whEveMapper.DefineEveSystemNodeModel(new WHSystem(DEFAULT_MAP_ID, 31001531, C4_NAME_BUG_207, -1.0f));
         Assert.Equal(EveSystemType.C4, result.SystemType);
+    }
+
+    [Fact, Priority(5)]
+    public async Task Is_Route_Via_WH()
+    {
+        var src = new SystemEntity(SOLAR_SYSTEM_WH_ID, SOLAR_SYSTEM_WH_NAME, CONSTELLATION_WH_ID, -1.0f, new int[] { });//fake for test
+        var dst = new SystemEntity(SOLAR_SYSTEM_JITA_ID,SOLAR_SYSTEM_JITA_NAME, CONSTALLATION_JITA_ID, -1.0f, new int[] {50001248 });//fake for test
+
+        var result = await _whEveMapper.IsRouteViaWH(src, dst);
+        Assert.True(result);
+
+        var src2 = new SystemEntity(SOLAR_SYSTEM_JITA_ID, SOLAR_SYSTEM_JITA_NAME, CONSTALLATION_JITA_ID, -1.0f, new int[] { 50001248});
+        var dst2 = new SystemEntity(30000140, "Maurasi", CONSTALLATION_JITA_ID, -1.0f, new int[] { 50000802});
+
+        var result_wh = await _whEveMapper.IsRouteViaWH(src2, dst2);
+        Assert.False(result_wh);
     }
 }
 

--- a/src/WHMapper/Models/DTO/EveMapper/Enums/EveEntityEnums.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/Enums/EveEntityEnums.cs
@@ -3,6 +3,17 @@
     {
             Character,
             Corporation,
-            Alliance
+            Alliance,
+            Ship,
+            System,
+            Constellation,
+            Region,
+            Stargate,
+            Station,
+            Structure,
+            Group,
+            Wormhole,
+            Sun,
+            
     }
 }

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/AllianceEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/AllianceEntity.cs
@@ -1,4 +1,5 @@
-﻿using WHMapper.Models.DTO.EveAPI.Alliance;
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveAPI.Alliance;
 using WHMapper.Models.DTO.EveMapper.Enums;
 
 namespace WHMapper.Models.DTO.EveMapper.EveEntity
@@ -8,6 +9,12 @@ namespace WHMapper.Models.DTO.EveMapper.EveEntity
     {
         public AllianceEntity(int id, Alliance entity) 
             : base(id, entity.Name, EveEntityEnums.Alliance)
+        {
+        }
+
+        [JsonConstructor]
+        public AllianceEntity(int id, string name)
+            : base(id, name, EveEntityEnums.Alliance)
         {
         }
     }

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/CharactereEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/CharactereEntity.cs
@@ -1,4 +1,5 @@
-﻿using WHMapper.Models.DTO.EveAPI.Alliance;
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveAPI.Alliance;
 using WHMapper.Models.DTO.EveAPI.Character;
 using WHMapper.Models.DTO.EveMapper.Enums;
 
@@ -8,6 +9,12 @@ namespace WHMapper.Models.DTO.EveMapper.EveEntity
     {
         public CharactereEntity(int id, Character entity)
             : base(id, entity.Name, EveEntityEnums.Character)
+        {
+        }
+
+        [JsonConstructor]
+        public CharactereEntity(int id, string name)
+            : base(id, name, EveEntityEnums.Character)
         {
         }
     }

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/ConstellationEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/ConstellationEntity.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveAPI.Universe;
+using WHMapper.Models.DTO.EveMapper.Enums;
+using WHMapper.Models.DTO.EveMapper.EveEntity;
+
+namespace WHMapper.Models.DTO.EveMapper.EveEntity;
+
+public class ConstellationEntity : AEveEntity
+{
+
+    public int RegionId { get; private set; }
+    public int[] Systems { get; private set; }
+
+    public ConstellationEntity(int id, Constellation constellation)
+        : base(id, constellation.Name, EveEntityEnums.Constellation)
+    {
+        RegionId = constellation.RegionId;
+        Systems = constellation.Systems;
+    }
+
+    [JsonConstructor]
+    public ConstellationEntity(int id, string name, int regionId, int[] systems)
+        : base(id, name, EveEntityEnums.Constellation)
+    {
+        RegionId = regionId;
+        Systems = systems;
+    }
+}

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/CorporationEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/CorporationEntity.cs
@@ -1,4 +1,5 @@
-﻿using WHMapper.Models.DTO.EveAPI.Corporation;
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveAPI.Corporation;
 using WHMapper.Models.DTO.EveMapper.Enums;
 
 namespace WHMapper.Models.DTO.EveMapper.EveEntity
@@ -7,6 +8,12 @@ namespace WHMapper.Models.DTO.EveMapper.EveEntity
     {
         public CorporationEntity(int id, Corporation entity)
             : base(id, entity.Name, EveEntityEnums.Corporation)
+        {
+        }
+
+        [JsonConstructor]
+        public CorporationEntity(int id, string name)
+            : base(id, name, EveEntityEnums.Corporation)
         {
         }
     }

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/GroupEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/GroupEntity.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveAPI.Universe;
+using WHMapper.Models.DTO.EveMapper.Enums;
+
+namespace WHMapper.Models.DTO.EveMapper.EveEntity;
+
+public class GroupEntity : AEveEntity
+{
+    public int[] Types { get; private set; }
+    public int CategoryId { get; private set; }
+    public GroupEntity(int id, Group group)
+        : base(id, group.Name, EveEntityEnums.Group)
+    {
+        Types = group.Types;
+        CategoryId = group.CategoryId;
+    }
+
+    [JsonConstructor]
+    public GroupEntity(int id, string name,int[] types,int categoryId)
+        : base(id, name, EveEntityEnums.Group)
+    {
+        Types = types;
+        CategoryId = categoryId;
+
+    }
+
+
+}

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/RegionEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/RegionEntity.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveAPI.Universe;
+using WHMapper.Models.DTO.EveMapper.Enums;
+using WHMapper.Models.DTO.EveMapper.EveEntity;
+
+namespace WHMapper.Models.DTO.EveMapper.EveEntity;
+
+public class RegionEntity : AEveEntity
+{
+    public int[] Constellations { get; private set; }
+
+    public RegionEntity(int id, Region region)
+        : base(id, region.Name, EveEntityEnums.Region)
+    {
+        Constellations = region.Constellations;
+
+    }
+
+    [JsonConstructor]
+    public RegionEntity(int id, string name, int[] constellations)
+        : base(id, name, EveEntityEnums.Region)
+    {
+        Constellations = constellations;
+    }
+}

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/ShipEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/ShipEntity.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveMapper.Enums;
+
+namespace WHMapper.Models.DTO.EveMapper.EveEntity;
+
+public class ShipEntity: AEveEntity
+{
+        public float Mass {get;private set;}
+        public ShipEntity(int id, Models.DTO.EveAPI.Universe.Type entity)
+            : base(id, entity.Name, EveEntityEnums.Ship)
+        {
+            Mass = entity.Mass;
+        }
+
+        [JsonConstructor]
+        public ShipEntity(int id, string name,float mass)
+            : base(id, name, EveEntityEnums.Ship)
+        {
+            Mass = mass;
+        }
+}
+
+

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/StargateEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/StargateEntity.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveAPI.Universe;
+using WHMapper.Models.DTO.EveMapper.Enums;
+
+namespace WHMapper.Models.DTO.EveMapper.EveEntity;
+
+public class StargateEntity : AEveEntity
+{
+    public int DestinationId { get; private set; }
+    public int SourceId { get; private set; }
+
+    public StargateEntity(int id, Stargate entity)
+        : base(id, entity.Name, EveEntityEnums.Stargate)
+    {
+        DestinationId = entity.Destination.SystemId;
+        SourceId = entity.SystemId;
+    }
+
+    [JsonConstructor]
+    public StargateEntity(int id, string name, int destinationId, int sourceId)
+        : base(id, name, EveEntityEnums.Stargate)
+    {
+        DestinationId = destinationId;
+        SourceId = sourceId;
+    }
+
+}

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/SunEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/SunEntity.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveMapper.Enums;
+
+namespace WHMapper.Models.DTO.EveMapper.EveEntity;
+
+public class SunEntity : AEveEntity
+{
+    public SunEntity(int id, WHMapper.Models.DTO.EveAPI.Universe.Type type)
+        : base(id, type.Name, EveEntityEnums.Sun)
+    {
+    }
+
+    [JsonConstructor]
+    public SunEntity(int id, string name)
+        : base(id, name, EveEntityEnums.Sun)
+    {
+    }
+
+}

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/SystemEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/SystemEntity.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveMapper.Enums;
+using WHMapper.Models.DTO.SDE;
+
+namespace WHMapper.Models.DTO.EveMapper.EveEntity
+{
+    public class SystemEntity : AEveEntity
+    {
+        public int ConstellationId { get; private set; }
+        public float SecurityStatus { get; private set; }
+        public int [] Stargates { get; private set; }
+
+        public SystemEntity(int id, Models.DTO.EveAPI.Universe.ESISolarSystem entity)
+            : base(id, entity.Name, EveEntityEnums.System)
+        {
+            SecurityStatus = entity.SecurityStatus;
+            Stargates = entity.Stargates;
+            ConstellationId = entity.ConstellationId;
+        }
+
+        [JsonConstructor]
+        public SystemEntity(int id, string name,int constellationId,float securityStatus,int[] stargates)
+            : base(id, name, EveEntityEnums.System)
+        {
+            SecurityStatus = securityStatus;
+            Stargates = stargates;
+            ConstellationId = constellationId;
+        }
+    }
+}
+

--- a/src/WHMapper/Models/DTO/EveMapper/EveEntity/WHEntity.cs
+++ b/src/WHMapper/Models/DTO/EveMapper/EveEntity/WHEntity.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.Json.Serialization;
+using WHMapper.Models.DTO.EveAPI.Universe;
+using WHMapper.Models.DTO.EveMapper.Enums;
+
+namespace WHMapper.Models.DTO.EveMapper.EveEntity;
+
+public class WHEntity : AEveEntity
+{
+    private const int DOGMA_ATTR_TARGET_SYSTEM_CLASS_FOR_WORMHOLES_ID = 1381;
+    //private const int DOGMA_ATTR_DISTRIBUTION_ID_OF_TARGET_WORMHOLE_DISTRIBUTION_ID = 1457;
+    
+    public float SystemTypeValue { get; private set; }
+
+    public WHEntity(int id, WHMapper.Models.DTO.EveAPI.Universe.Type type)
+        : base(id, type.Name[9..], EveEntityEnums.Wormhole)
+    {
+        if (type.DogmaAttributes != null)
+            SystemTypeValue = type.DogmaAttributes.Where(x => x.AttributeId == DOGMA_ATTR_TARGET_SYSTEM_CLASS_FOR_WORMHOLES_ID).Select(x => x.Value).FirstOrDefault(0);
+        else
+            SystemTypeValue = 0;
+    }
+
+    [JsonConstructor]
+    public WHEntity(int id, string name,float systemTypeValue)
+        : base(id, name, EveEntityEnums.Wormhole)
+    {
+        SystemTypeValue = systemTypeValue;
+    }
+
+}

--- a/src/WHMapper/Pages/Mapper/Add.cs
+++ b/src/WHMapper/Pages/Mapper/Add.cs
@@ -12,6 +12,7 @@ using MudBlazor.Charts;
 using WHMapper.Models.Custom.Node;
 using WHMapper.Models.Db;
 using WHMapper.Models.DTO.EveAPI.Universe;
+using WHMapper.Models.DTO.EveMapper.EveEntity;
 using WHMapper.Models.DTO.SDE;
 using WHMapper.Repositories.WHMaps;
 using WHMapper.Repositories.WHSystems;
@@ -41,7 +42,7 @@ namespace WHMapper.Pages.Mapper
         private IEveMapperHelper MapperServices { get; set; } = null!;
 
         [Inject]
-        private IEveAPIServices EveServices { get; set; } = null!;
+        private IEveMapperEntity EveMapperEntity { get; set; } = null!;
 
         [Inject]
         IWHSystemRepository DbWHSystems { get; set; } = null!;
@@ -115,7 +116,9 @@ namespace WHMapper.Pages.Mapper
 
                     int solarSystemId = ((_searchResult==null) ? -1 : _searchResult.SolarSystemID);
                     int currentMapId = ((CurrentWHMap == null) ? -1 : CurrentWHMap.Id);
-                    var solarSystem = await EveServices.UniverseServices.GetSystem(solarSystemId);
+                    SystemEntity? solarSystem = await EveMapperEntity.GetSystem(solarSystemId);
+                    
+
                     WHSystem? newWHSystem=null!;
                     if (solarSystem == null)
                     {
@@ -124,7 +127,7 @@ namespace WHMapper.Pages.Mapper
                         MudDialog.Close(DialogResult.Cancel);
                     }
                     else
-                        newWHSystem = await DbWHSystems.Create(new WHSystem(currentMapId,solarSystem.SystemId, solarSystem.Name, solarSystem.SecurityStatus, MouseX, MouseY)); //change position
+                        newWHSystem = await DbWHSystems.Create(new WHSystem(currentMapId,solarSystem.Id, solarSystem.Name, solarSystem.SecurityStatus, MouseX, MouseY)); //change position
 
 
                     if (newWHSystem == null)
@@ -165,26 +168,6 @@ namespace WHMapper.Pages.Mapper
         {
             MudDialog.Cancel();
         }
-
-/*
-        private async Task<IEnumerable<SDEServices>?> Search(string value,CancellationToken cancellationToken)
-        {
-            try
-            {
-                return (IEnumerable<SDEServices>?)await EveMapperSearch.SearchSystem(value,cancellationToken);
-            }
-            catch(OperationCanceledException)
-            {
-                Logger.LogInformation($"SearchSystem {value} cancelled");
-                return null;
-            }
-            catch(Exception ex)
-            {
-                Logger.LogError(ex, MSG_SEARCH_ERROR);
-                Snackbar.Add(MSG_SEARCH_ERROR, Severity.Error);
-                return null;
-            }
-        }*/
     }
 }
 

--- a/src/WHMapper/Pages/Mapper/LinkInfos/Overview.cs
+++ b/src/WHMapper/Pages/Mapper/LinkInfos/Overview.cs
@@ -7,6 +7,7 @@ using WHMapper.Models.Custom.Node;
 using WHMapper.Models.Db;
 using WHMapper.Repositories.WHSystemLinks;
 using WHMapper.Services.EveAPI;
+using WHMapper.Services.EveMapper;
 using WHMapper.Services.WHColor;
 
 namespace WHMapper.Pages.Mapper.LinkInfos;
@@ -16,13 +17,15 @@ public partial class Overview : ComponentBase
 {
         [Inject]
         private ILogger<Overview> Logger { get; set; } = null!;
-        [Inject]
-        private IEveAPIServices EveAPIServices { get; set; } = null!;
+
         [Inject]
         private IWHSystemLinkRepository DbSystemLink { get; set; } = null!;
         
         [Inject]
         private IWHColorHelper? WHColorHelper { get; set; }
+
+        [Inject]
+        private IEveMapperEntity EveMapperEntity { get; set; } = null!;
 
         [Parameter]
         public EveSystemLinkModel CurrentSystemLink {get;set;}= null!;
@@ -106,7 +109,7 @@ public partial class Overview : ComponentBase
                         return string.Empty;
                 }
 
-                var character = await EveAPIServices.CharacterServices.GetCharacter(jumplog.CharacterId);
+                var character = await EveMapperEntity.GetCharacter(jumplog.CharacterId);
 
                 if (character == null)
                 {
@@ -130,7 +133,7 @@ public partial class Overview : ComponentBase
                         return "No ship used";
                 }
 
-                var shipInfos = await EveAPIServices.UniverseServices.GetType(jumplog!.ShipTypeId!.Value);
+                var shipInfos = await EveMapperEntity.GetShip(jumplog.ShipTypeId.Value);
 
                 if (shipInfos == null)
                 {

--- a/src/WHMapper/Pages/Mapper/Overview.cs
+++ b/src/WHMapper/Pages/Mapper/Overview.cs
@@ -31,6 +31,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.ValueGeneration.Internal;
 using BlazorContextMenu;
 using WHMapper.Repositories.WHNotes;
 using WHMapper.Services.WHColor;
+using WHMapper.Models.DTO.EveMapper.EveEntity;
 
 namespace WHMapper.Pages.Mapper
 {
@@ -48,7 +49,7 @@ namespace WHMapper.Pages.Mapper
         private ICollection<EveSystemNodeModel>? _selectedSystemNodes = null;
         private ICollection<EveSystemLinkModel>? _selectedSystemLinks = null;
 
-        private SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
 
         private HubConnection _hubConnection=null!;
 
@@ -103,8 +104,6 @@ namespace WHMapper.Pages.Mapper
         [Inject]
         private IPasteServices PasteServices {get;set;}=null!;
 
-        [Inject]
-        IWHColorHelper WHColorHelper { get; set; } = null!;
 
         private string _userName = string.Empty;
         private int _characterId = 0;
@@ -136,9 +135,9 @@ namespace WHMapper.Pages.Mapper
         //private bool _isAdmin = false;
 
 
-        private ESISolarSystem? _currentSolarSystem = null!;
+        private SystemEntity? _currentSolarSystem = null!;
         private Ship? _currentShip = null!;
-        private Models.DTO.EveAPI.Universe.Type? _currentShipInfos = null!;
+        private ShipEntity? _currentShipInfos = null!;
 
         protected override async Task OnInitializedAsync()
         {
@@ -305,9 +304,9 @@ namespace WHMapper.Pages.Mapper
                             if (DbWHMaps!=null && _selectedWHMap!=null && wormholeId > 0 && _selectedWHMap.Id== mapId)
                             {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
-                                var systemNodeToDelete = _blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).IdWH == wormholeId);
+                                var systemNodeToDelete = _blazorDiagram.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).IdWH == wormholeId);
                                 if (systemNodeToDelete != null)
-                                    _blazorDiagram?.Nodes?.Remove(systemNodeToDelete);
+                                    _blazorDiagram.Nodes?.Remove(systemNodeToDelete);
                                 else
                                 {
                                     Logger.LogWarning("On NotifyWormholeRemoved, unable to find system to remove");
@@ -335,7 +334,7 @@ namespace WHMapper.Pages.Mapper
                                     EveSystemNodeModel? newSystemNodeFrom = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => (x as EveSystemNodeModel)!.IdWH == link.IdWHSystemFrom));
                                     EveSystemNodeModel? newSystemNodeTo = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => (x as EveSystemNodeModel)!.IdWH == link.IdWHSystemTo));
                                     if(newSystemNodeTo!=null && newSystemNodeFrom!=null)
-                                        _blazorDiagram?.Links?.Add(new EveSystemLinkModel(link, newSystemNodeFrom, newSystemNodeTo));
+                                        _blazorDiagram.Links?.Add(new EveSystemLinkModel(link, newSystemNodeFrom, newSystemNodeTo));
                                     else
                                     {
                                         Logger.LogWarning("On NotifyLinkAdded, unable to find system to add link");
@@ -358,9 +357,9 @@ namespace WHMapper.Pages.Mapper
                             { 
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
 
-                                var linkToDel = _blazorDiagram?.Links?.FirstOrDefault(x => ((EveSystemLinkModel)x).Id == linKId);
+                                var linkToDel = _blazorDiagram.Links?.FirstOrDefault(x => ((EveSystemLinkModel)x).Id == linKId);
                                 if (linkToDel != null)
-                                    _blazorDiagram?.Links?.Remove(linkToDel);
+                                    _blazorDiagram.Links?.Remove(linkToDel);
                                 else
                                 {
                                     Logger.LogWarning("On NotifyLinkRemoved, unable to find link to remove");
@@ -379,7 +378,7 @@ namespace WHMapper.Pages.Mapper
                     {
                         try
                         {
-                            if (DbWHMaps != null && _selectedWHMap != null && wormholeId > 0 && _selectedWHMap?.Id == mapId)
+                            if (DbWHMaps != null && _selectedWHMap != null && wormholeId > 0 && _selectedWHMap.Id == mapId)
                             {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
 
@@ -403,7 +402,7 @@ namespace WHMapper.Pages.Mapper
                     {
                         try
                         {
-                            if (DbWHMaps != null && linkId > 0 && _selectedWHMap != null && _selectedWHMap?.Id == mapId)
+                            if (DbWHMaps != null && linkId > 0 && _selectedWHMap != null && _selectedWHMap.Id == mapId)
                             {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
                                 var linkToChanged = _blazorDiagram?.Links?.FirstOrDefault(x => ((EveSystemLinkModel)x).Id == linkId);
@@ -431,7 +430,7 @@ namespace WHMapper.Pages.Mapper
                     {
                         try
                         {
-                            if (DbWHMaps != null && _selectedWHMap != null && wormholeId > 0 && _selectedWHMap?.Id == mapId)
+                            if (DbWHMaps != null && _selectedWHMap != null && wormholeId > 0 && _selectedWHMap.Id == mapId)
                             {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
                                 EveSystemNodeModel? systemToIncrementNameExtenstion = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).IdWH == wormholeId);
@@ -462,7 +461,7 @@ namespace WHMapper.Pages.Mapper
                     {
                         try
                         {
-                            if (DbWHMaps != null && _selectedWHMap != null && wormholeId > 0 && _selectedWHMap?.Id == mapId)
+                            if (DbWHMaps != null && _selectedWHMap != null && wormholeId > 0 && _selectedWHMap.Id == mapId)
                             {
                                 _selectedWHMap = await DbWHMaps.GetById(mapId);
                                 if(WHSignaturesView!=null && WHSignaturesView.CurrentSystemNodeId ==wormholeId)
@@ -759,7 +758,7 @@ namespace WHMapper.Pages.Mapper
         #region Diagram Keyboard Pressed
         private async Task<bool> OnLinkSystemKeyPressed(Blazor.Diagrams.Core.Events.KeyboardEventArgs eventArgs)
         {
-            if (eventArgs.Code == "KeyL" && _selectedWHMap != null && _selectedSystemNodes != null && _selectedSystemNodes.Count() == 2)
+            if (eventArgs.Code == "KeyL" && _selectedWHMap != null && _selectedSystemNodes != null && _selectedSystemNodes.Count == 2)
             { 
                 if (IsLinkExist(_selectedSystemNodes.ElementAt(0), _selectedSystemNodes.ElementAt(1)))
                 {
@@ -863,30 +862,6 @@ namespace WHMapper.Pages.Mapper
 
         #endregion
 
-/*
-        private async Task OnDiagramPointerLeave(Blazor.Diagrams.Core.Models.Base.Model? item, Blazor.Diagrams.Core.Events.PointerEventArgs eventArgs)
-        {
-            if (item == null)
-                return;
-
-            if (item.GetType() == typeof(EveSystemLinkModel))
-            {
-
-            }
-        }
-
-        private async Task OnDiagramPointerEnter(Blazor.Diagrams.Core.Models.Base.Model? item, Blazor.Diagrams.Core.Events.PointerEventArgs eventArgs)
-        {
-            if (item == null)
-                return;
-
-            if (item.GetType() == typeof(EveSystemLinkModel))
-            {
-
-            }
-
-
-        }*/
         private async Task OnDiagramPointerUp(Blazor.Diagrams.Core.Models.Base.Model? item, Blazor.Diagrams.Core.Events.PointerEventArgs eventArgs)
         {
             if (item == null)
@@ -1191,47 +1166,8 @@ namespace WHMapper.Pages.Mapper
             }
 
         }
-        private async Task<bool> IsRouteViaWH(ESISolarSystem src, ESISolarSystem dst)
-        {
-            if (src == null)
-                return false;
 
-            if (dst == null)
-                return false;
-
-
-            if((src != null && src.Stargates==null) || dst.Stargates==null)
-                return true;
-            else
-            {
-                int[]? startgatesToCheck = null;
-                int systemTarget = -1;
-                if (src!=null && src.Stargates.Length <= dst.Stargates.Length)
-                {
-                    startgatesToCheck = dst.Stargates;
-                    systemTarget = src.SystemId;
-                }
-                else
-                {
-                    startgatesToCheck = src?.Stargates;
-                    systemTarget = dst.SystemId;
-                }
-
-                if (startgatesToCheck == null)
-                    return true;
-                    
-                foreach (int sgId in startgatesToCheck)
-                {
-                    var sg = await EveServices.UniverseServices.GetStargate(sgId);
-
-                    if (sg!=null && sg.Destination.SystemId == systemTarget)
-                        return false;
-                }
-
-                 return true;
-            }
-        }
-        private async Task<bool> AddSystemNode(WHMap map,ESISolarSystem? src,ESISolarSystem target)
+        private async Task<bool> AddSystemNode(WHMap map,SystemEntity? src,SystemEntity target)
         {
             EveSystemNodeModel? previousSystemNode = null;
             WHSystem? newWHSystem= null;
@@ -1245,7 +1181,7 @@ namespace WHMapper.Pages.Mapper
                 //determine position on map. depends of previous system , todo refactor
                 if (src != null)
                 {
-                    previousSystemNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == src.SystemId));
+                    previousSystemNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == src.Id));
             
                     if(previousSystemNode!=null)
                     {
@@ -1260,12 +1196,12 @@ namespace WHMapper.Pages.Mapper
                 }
 
                 //determine if source have same system link and get next unique ident
-                if(src != null && await IsRouteViaWH(src, target)) //check if HS/LS/NS to HS/LS/NS via WH not gate
+                if(src != null && await MapperServices.IsRouteViaWH(src, target)) //check if HS/LS/NS to HS/LS/NS via WH not gate
                 {
 
                     //get whClass an determine if another connection to another wh with same class exist from previous system. Increment extension value in that case
                     EveSystemType whClass = await MapperServices.GetWHClass(target);
-                    var sameWHClassWHList = _blazorDiagram?.Links?.Where(x =>  ((EveSystemNodeModel)(x.Target!.Model!)).SystemType == whClass && ((EveSystemNodeModel)x.Source!.Model!).SolarSystemId == src.SystemId);
+                    var sameWHClassWHList = _blazorDiagram?.Links?.Where(x =>  ((EveSystemNodeModel)(x.Target!.Model!)).SystemType == whClass && ((EveSystemNodeModel)x.Source!.Model!).SolarSystemId == src.Id);
                     
                     if(sameWHClassWHList!=null)
                         nbSameWHClassLink = sameWHClassWHList.Count();
@@ -1275,14 +1211,14 @@ namespace WHMapper.Pages.Mapper
                     if (nbSameWHClassLink > 0)
                     {
                         extension = (Char)(Convert.ToUInt16('A') + (nbSameWHClassLink));
-                        newWHSystem = await DbWHSystems.Create(new WHSystem(map.Id, target.SystemId, target.Name, extension, target.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
+                        newWHSystem = await DbWHSystems.Create(new WHSystem(map.Id, target.Id, target.Name, extension, target.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
                     }
                     else
-                        newWHSystem = await DbWHSystems.Create(new WHSystem(map.Id, target.SystemId, target.Name, target.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
+                        newWHSystem = await DbWHSystems.Create(new WHSystem(map.Id, target.Id, target.Name, target.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
                 
                 }
                 else
-                    newWHSystem = await DbWHSystems.Create(new WHSystem(map.Id,target.SystemId,target.Name, target.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
+                    newWHSystem = await DbWHSystems.Create(new WHSystem(map.Id,target.Id,target.Name, target.SecurityStatus, defaultNewSystemPosX, defaultNewSystemPosY));
 
                 if (newWHSystem!=null)
                 {
@@ -1322,7 +1258,7 @@ namespace WHMapper.Pages.Mapper
                 return false;
             }
         }
-        private async Task<bool> AddSystemNodeLink(WHMap map, ESISolarSystem src, ESISolarSystem target)
+        private async Task<bool> AddSystemNodeLink(WHMap map, SystemEntity src, SystemEntity target)
         {
             if (_blazorDiagram == null  || map == null || src == null || target == null)
             {
@@ -1330,8 +1266,8 @@ namespace WHMapper.Pages.Mapper
                 return false;
             }
 
-            EveSystemNodeModel? srcNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == src.SystemId));
-            EveSystemNodeModel? targetNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == target.SystemId));
+            EveSystemNodeModel? srcNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == src.Id));
+            EveSystemNodeModel? targetNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == target.Id));
     
             return await AddSystemNodeLink(map,srcNode,targetNode);
         }
@@ -1404,14 +1340,14 @@ namespace WHMapper.Pages.Mapper
             return await AddSystemNodeLinkLog(link.Id,isManual);
         }
 
-        private Task OnShipChanged(Ship ship,Models.DTO.EveAPI.Universe.Type shipInfos)
+        private Task OnShipChanged(Ship ship,ShipEntity shipInfos)
         {
             _currentShip=ship;
             _currentShipInfos=shipInfos;
 
             return Task.CompletedTask;
         }
-        private async Task OnSystemChanged(ESISolarSystem targetSoloarSystem)
+        private async Task OnSystemChanged(SystemEntity targetSoloarSystem)
         {
             EveSystemNodeModel? srcNode  = null;
             EveSystemNodeModel? targetNode = null;
@@ -1434,9 +1370,9 @@ namespace WHMapper.Pages.Mapper
                 
                 if(_currentSolarSystem!=null)
                 {
-                    srcNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == _currentSolarSystem.SystemId));
+                    srcNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == _currentSolarSystem.Id));
                 }
-                targetNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == targetSoloarSystem.SystemId));
+                targetNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == targetSoloarSystem.Id));
                 
 
                 if (targetNode== null)//System is not added
@@ -1452,7 +1388,7 @@ namespace WHMapper.Pages.Mapper
                             }
                             else
                             {
-                                targetNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == targetSoloarSystem.SystemId));
+                                targetNode = (EveSystemNodeModel?)(_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).SolarSystemId == targetSoloarSystem.Id));
                             }
                         }
 

--- a/src/WHMapper/Program.cs
+++ b/src/WHMapper/Program.cs
@@ -197,6 +197,7 @@ namespace WHMapper
             #endregion
 
             #region WH HELPER
+            builder.Services.AddScoped<IEveMapperEntity, EveMapperEntity>();
             builder.Services.AddScoped<IEveMapperAccessHelper, EveMapperAccessHelper>();
             builder.Services.AddScoped<IEveMapperTracker, EveMapperTracker>();
             builder.Services.AddScoped<IEveMapperSearch, EveMapperSearch>();

--- a/src/WHMapper/Services/EveAPI/Universe/IUniverseServices.cs
+++ b/src/WHMapper/Services/EveAPI/Universe/IUniverseServices.cs
@@ -17,7 +17,7 @@ namespace WHMapper.Services.EveAPI.Universe
         Task<int[]?> GetTypes();
         Task<Stargate?> GetStargate(int stargate_id);
         Task<int[]?> GetContellations();
-        Task<Constellation?> GetContellation(int constellatio_id);
+        Task<Constellation?> GetConstellation(int constellatio_id);
         Task<int[]?> GetRegions();
         Task<Region?> GetRegion(int region_id);
     }

--- a/src/WHMapper/Services/EveAPI/Universe/UniverseServices.cs
+++ b/src/WHMapper/Services/EveAPI/Universe/UniverseServices.cs
@@ -70,7 +70,7 @@ namespace WHMapper.Services.EveAPI.Universe
 
         }
 
-        public async Task<Constellation?> GetContellation(int constellatio_id)
+        public async Task<Constellation?> GetConstellation(int constellatio_id)
         {
             return await base.Execute<Constellation>(RequestSecurity.Public, RequestMethod.Get, string.Format("/v1/universe/constellations/{0}/?datasource=tranquility", constellatio_id));
 

--- a/src/WHMapper/Services/EveMapper/EveMapperEntity.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperEntity.cs
@@ -1,0 +1,728 @@
+﻿using System.Collections.Concurrent;
+using WHMapper.Models.DTO.EveAPI.Alliance;
+using WHMapper.Models.DTO.EveAPI.Character;
+using WHMapper.Models.DTO.EveAPI.Corporation;
+using WHMapper.Models.DTO.EveAPI.Universe;
+using WHMapper.Models.DTO.EveMapper.EveEntity;
+using WHMapper.Models.DTO.SDE;
+using WHMapper.Services.Cache;
+using WHMapper.Services.EveAPI;
+using WHMapper.Services.SDE;
+
+namespace WHMapper.Services.EveMapper;
+
+public class EveMapperEntity : IEveMapperEntity
+{
+    private readonly ILogger<EveMapperEntity> _logger;
+    private readonly ICacheService _cacheService;
+    private readonly IEveAPIServices _eveApiService;
+
+    public EveMapperEntity(ILogger<EveMapperEntity> logger, ICacheService cacheService, IEveAPIServices eveApiService)
+    {
+        _logger = logger;
+        _cacheService = cacheService;
+        _eveApiService = eveApiService;
+    }
+
+    private Task<string> GetEntityCacheKey<T>() where T : AEveEntity
+    {
+        switch (typeof(T).Name)
+        {
+            case "AllianceEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_ALLIANCE_KEY);
+            case "CorporationEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_COORPORATION_KEY);
+            case "CharactereEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_CHARACTER_KEY);
+            case "ShipEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_SHIP_KEY);
+            case "SystemEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_SYSTEM_KEY);
+            case "ConstellationEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_CONSTELLATION_KEY);
+            case "RegionEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_REGION_KEY);
+            case "StargateEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_STARTGATE_KEY);
+            case "GroupEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_GROUP_KEY);
+            case "WHEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_WORMHOLE_KEY);
+            case "SunEntity":
+                return Task.FromResult(IEveMapperEntity.REDIS_SUN_KEY);
+            default:
+                throw new InvalidCastException("Invalid entity type");
+        }
+    }
+
+    private async Task<IEnumerable<T>?> GetEntitiesFromCache<T>() where T : AEveEntity
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<T>();
+            return await _cacheService.Get<IEnumerable<T>>(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting entities {entity}", typeof(T).Name);
+            return null;
+        }
+    }
+
+    private async Task<bool> SetEntityCahing<T>(T entity) where T : AEveEntity
+    {
+        try
+        {
+            IEnumerable<T>? results = await GetEntitiesFromCache<T>();
+            if(results == null)
+            {
+                results = new HashSet<T>();
+            }
+
+            if(results.Contains(entity))
+            {
+                _logger.LogInformation("{entityName} already in cache", typeof(T).Name);
+                return true;
+            }
+
+            string redis_key = await GetEntityCacheKey<T>();
+            return await _cacheService.Set(redis_key, results.Append(entity));
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while saving entity {entity}", typeof(T).Name);
+            return false;
+        }
+    }
+
+
+    public async Task<AllianceEntity?> GetAlliance(int allianceId)
+    {
+        try
+        {
+            IEnumerable<AllianceEntity>? results = await GetEntitiesFromCache<AllianceEntity>();
+            if(results != null)
+            {
+                AllianceEntity? entityItem = results.FirstOrDefault(x => x.Id == allianceId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get alliance from API
+            Alliance? alliance = await _eveApiService.AllianceServices.GetAlliance(allianceId);
+            if(alliance == null)
+            {
+                _logger.LogWarning("Alliance {allianceId} not found", allianceId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            AllianceEntity entity = new AllianceEntity(allianceId,alliance);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+            
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting alliance {allianceId}", allianceId);
+            return null;
+        }
+    }
+
+    public async Task<CharactereEntity?> GetCharacter(int characterId)
+    {
+        try
+        {
+            IEnumerable<CharactereEntity>? results = await GetEntitiesFromCache<CharactereEntity>();
+            if(results != null)
+            {
+                CharactereEntity? entityItem = results.FirstOrDefault(x => x.Id == characterId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get character from API
+            Character? character = await _eveApiService.CharacterServices.GetCharacter(characterId);
+            if(character == null)
+            {
+                _logger.LogWarning("Character {characterId} not found", characterId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            CharactereEntity entity = new CharactereEntity(characterId,character);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting character {characterId}", characterId);
+            return null;
+        }
+    }
+
+    public async Task<CorporationEntity?> GetCorporation(int corporationId)
+    {
+        try
+        {
+            IEnumerable<CorporationEntity>? results = await GetEntitiesFromCache<CorporationEntity>();
+            if(results != null)
+            {
+                CorporationEntity? entityItem = results.FirstOrDefault(x => x.Id == corporationId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get corporation from API
+            Corporation? corporation = await _eveApiService.CorporationServices.GetCorporation(corporationId);
+            if(corporation == null)
+            {
+                _logger.LogWarning("Corporation {corporationId} not found", corporationId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            CorporationEntity entity = new CorporationEntity(corporationId,corporation);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting corporation {corporationId}", corporationId);
+            return null;
+        }
+    }
+
+    public async Task<ShipEntity?> GetShip(int shipTypeId)
+    {
+       try
+       {
+              IEnumerable<ShipEntity>? results = await GetEntitiesFromCache<ShipEntity>();
+              if(results != null)
+              {
+                ShipEntity? entityItem = results.FirstOrDefault(x => x.Id == shipTypeId);
+    
+                if(entityItem != null)
+                {
+                     _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                     return entityItem;
+                }
+              }
+    
+              // Get ship from API
+              Models.DTO.EveAPI.Universe.Type? ship = await _eveApiService.UniverseServices.GetType(shipTypeId);
+              if(ship == null)
+              {
+                _logger.LogWarning("Ship {shipTypeId} not found", shipTypeId);
+                return null;
+              }
+    
+              //put on cache and return return entity
+              ShipEntity entity = new ShipEntity(shipTypeId,ship);
+              if(await SetEntityCahing(entity))
+              {
+                return entity;
+              }
+              else
+              {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+              }
+       }
+       catch (Exception e)
+       {
+           _logger.LogError(e, "Error while getting ship {shipTypeId}", shipTypeId);
+           return null;
+       }
+    }
+
+    public async Task<SystemEntity?> GetSystem(int systemId)
+    {
+        try
+        {
+
+            IEnumerable<SystemEntity>? results = await GetEntitiesFromCache<SystemEntity>();
+            if(results != null)
+            {
+                SystemEntity? entityItem = results.FirstOrDefault(x => x.Id == systemId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get system from API
+            ESISolarSystem? system = await _eveApiService.UniverseServices.GetSystem(systemId);
+            if(system == null)
+            {
+                _logger.LogWarning("System {systemId} not found", systemId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            SystemEntity entity = new SystemEntity(systemId,system);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting system {systemId}", systemId);
+            return null;
+        }
+    }
+
+    public async Task<ConstellationEntity?> GetConstellation(int constellationId)
+    {
+        try
+        {
+            IEnumerable<ConstellationEntity>? results = await GetEntitiesFromCache<ConstellationEntity>();
+            if(results != null)
+            {
+                ConstellationEntity? entityItem = results.FirstOrDefault(x => x.Id == constellationId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get constellation from API
+            Constellation? constellation = await _eveApiService.UniverseServices.GetConstellation(constellationId);
+            if(constellation == null)
+            {
+                _logger.LogWarning("Constellation {constellationId} not found", constellationId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            ConstellationEntity entity = new ConstellationEntity(constellationId,constellation);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting constellation {constellationId}", constellationId);
+            return null;
+        }
+    }
+
+    public async Task<RegionEntity?> GetRegion(int regionId)
+    {
+        try
+        {
+            IEnumerable<RegionEntity>? results = await GetEntitiesFromCache<RegionEntity>();
+            if(results != null)
+            {
+                RegionEntity? entityItem = results.FirstOrDefault(x => x.Id == regionId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get region from API
+            Region? region = await _eveApiService.UniverseServices.GetRegion(regionId);
+            if(region == null)
+            {
+                _logger.LogWarning("Region {regionId} not found", regionId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            RegionEntity entity = new RegionEntity(regionId,region);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting region {regionId}", regionId);
+            return null;
+        }
+    }
+    
+    public async Task<StargateEntity?> GetStargate(int stargateId)
+    {
+        try
+        {
+            IEnumerable<StargateEntity>? results = await GetEntitiesFromCache<StargateEntity>();
+            if(results != null)
+            {
+                StargateEntity? entityItem = results.FirstOrDefault(x => x.Id == stargateId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get stargate from API
+            Stargate? stargate = await _eveApiService.UniverseServices.GetStargate(stargateId);
+            if(stargate == null)
+            {
+                _logger.LogWarning("Stargate {stargateId} not found", stargateId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            StargateEntity entity = new StargateEntity(stargateId,stargate);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting stargate {stargateId}", stargateId);
+            return null;
+        }
+    }
+
+    public async Task<GroupEntity?> GetGroup(int groupId)
+    {
+        try
+        {
+            IEnumerable<GroupEntity>? results = await GetEntitiesFromCache<GroupEntity>();
+            if(results != null)
+            {
+                GroupEntity? entityItem = results.FirstOrDefault(x => x.Id == groupId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get group from API
+            Group? group = await _eveApiService.UniverseServices.GetGroup(groupId);
+            if(group == null)
+            {
+                _logger.LogWarning("Group {groupId} not found", groupId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            GroupEntity entity = new GroupEntity(groupId,group);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting group {groupId}", groupId);
+            return null;
+        }
+    }
+
+    public async Task<WHEntity?> GetWormhole(int wormholeTypeId)
+    {
+        try
+        {
+            IEnumerable<WHEntity>? results = await GetEntitiesFromCache<WHEntity>();
+            if(results != null)
+            {
+                WHEntity? entityItem = results.FirstOrDefault(x => x.Id == wormholeTypeId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get wormhole from API
+            Models.DTO.EveAPI.Universe.Type? wormhole = await _eveApiService.UniverseServices.GetType(wormholeTypeId);
+            if(wormhole == null)
+            {
+                _logger.LogWarning("Wormhole {wormholeTypeId} not found", wormholeTypeId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            WHEntity entity = new WHEntity(wormholeTypeId,wormhole);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting wormhole {wormholeTypeId}", wormholeTypeId);
+            return null;
+        }
+    }
+
+    public async Task<SunEntity?> GetSun(int sunTypeId)
+    {
+        try
+        {
+            IEnumerable<SunEntity>? results = await GetEntitiesFromCache<SunEntity>();
+            if(results != null)
+            {
+                SunEntity? entityItem = results.FirstOrDefault(x => x.Id == sunTypeId);
+
+                if(entityItem != null)
+                {
+                    _logger.LogInformation("{entityName} found in cache", entityItem.Name);
+                    return entityItem;
+                }
+            }
+
+            // Get sun from API
+            Models.DTO.EveAPI.Universe.Type? sun = await _eveApiService.UniverseServices.GetType(sunTypeId);
+            if(sun == null)
+            {
+                _logger.LogWarning("Sun {sunTypeId} not found", sunTypeId);
+                return null;
+            }
+
+            //put on cache and return return entity
+            SunEntity entity = new SunEntity(sunTypeId,sun);
+            if(await SetEntityCahing(entity))
+            {
+                return entity;
+            }
+            else
+            {
+                _logger.LogError("Error while saving entity {entity} on cache", entity.Name);
+                return null;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while getting sun {sunTypeId}", sunTypeId);
+            return null;
+        }
+
+    }
+
+    public async Task<bool> ClearAllianceCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<AllianceEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing alliance cache");
+            return false;
+        }
+    }
+
+    public async Task<bool> ClearCharacterCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<CharactereEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing character cache");
+            return false;
+        }
+    }
+
+    public async Task<bool> ClearCorporationCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<CorporationEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing corporation cache");
+            return false;
+        }
+    }
+
+    public async Task<bool> ClearShipCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<ShipEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing ship cache");
+            return false;
+        }
+    }
+
+    public async Task<bool> ClearSystemCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<SystemEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing system cache");
+            return false;
+        }
+    }
+
+    public async Task<bool> ClearConstellationCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<ConstellationEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing constellation cache");
+            return false;
+        }
+    }
+
+    public async Task<bool> ClearRegionCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<RegionEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing region cache");
+            return false;
+        }
+    }
+
+    public async Task<bool> ClearStargateCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<StargateEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing stargate cache");
+            return false;
+        }
+    }
+
+    public async Task<bool> ClearGroupCache()
+    {
+        try
+        {
+            string redis_key = await GetEntityCacheKey<GroupEntity>();
+            return await _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing group cache");
+            return false;
+        }
+    }
+
+    public Task<bool> ClearWormholeCache()
+    {
+        try
+        {
+            string redis_key = IEveMapperEntity.REDIS_WORMHOLE_KEY;
+            return _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing wormhole cache");
+            return Task.FromResult(false);
+        }
+    }
+
+    public Task<bool> ClearSunCache()
+    {
+        try
+        {
+            string redis_key = IEveMapperEntity.REDIS_SUN_KEY;
+            return _cacheService.Remove(redis_key);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while clearing sun cache");
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/WHMapper/Services/EveMapper/EveMapperSearch.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperSearch.cs
@@ -21,9 +21,9 @@ public class EveMapperSearch : IEveMapperSearch
         private const string MSG_CHARACTERS_REQUIRED = "Please enter 3 or more characters";
         private const string MSG_UNKNOW_VALUE= "Unknow value";
 
-        private ILogger _logger= null!;
-        private ISDEServices _sdeServices = null!;
-        private IEveAPIServices _eveAPIServices = null!;
+        private readonly ILogger _logger;
+        private readonly ISDEServices _sdeServices;
+        private readonly IEveAPIServices _eveAPIServices;
 
         public EveMapperSearch(ILogger<EveMapperSearch> logger,ISDEServices sdeServices,IEveAPIServices eveAPIServices)
         {

--- a/src/WHMapper/Services/EveMapper/IEveMapperEntity.cs
+++ b/src/WHMapper/Services/EveMapper/IEveMapperEntity.cs
@@ -1,0 +1,45 @@
+﻿using WHMapper.Models.DTO.EveMapper.EveEntity;
+
+namespace WHMapper.Services.EveMapper;
+
+public interface IEveMapperEntity
+{
+    const string REDIS_ALLIANCE_KEY = "alliance:list";
+    const string REDIS_COORPORATION_KEY = "coorporation:list";
+    const string REDIS_CHARACTER_KEY = "charactere:list";
+    const string REDIS_SHIP_KEY = "ship:list";
+    const string REDIS_SYSTEM_KEY = "system:list";
+    const string REDIS_CONSTELLATION_KEY = "constellation:list";
+    const string REDIS_REGION_KEY = "region:list";
+    const string REDIS_STARTGATE_KEY = "stargate:list";
+    const string REDIS_GROUP_KEY = "group:list";
+    const string REDIS_WORMHOLE_KEY = "wormhole:list";
+    const string REDIS_SUN_KEY = "sun:list";
+
+    
+
+    Task<CharactereEntity?> GetCharacter(int characterId);
+    Task<CorporationEntity?> GetCorporation(int corporationId);
+    Task<AllianceEntity?> GetAlliance(int allianceId);
+    Task<ShipEntity?> GetShip(int shipTypeId);
+    Task<SystemEntity?> GetSystem(int systemId);
+    Task<ConstellationEntity?> GetConstellation(int constellationId);
+    Task<RegionEntity?> GetRegion(int regionId);
+    Task<StargateEntity?> GetStargate(int stargateId);
+    Task<GroupEntity?> GetGroup(int groupId);
+    Task<WHEntity?> GetWormhole(int wormholeTypeId);
+    Task<SunEntity?> GetSun(int sunTypeId);
+
+
+    Task<bool> ClearCharacterCache();
+    Task<bool> ClearCorporationCache();
+    Task<bool> ClearAllianceCache();
+    Task<bool> ClearShipCache();
+    Task<bool> ClearSystemCache();
+    Task<bool> ClearConstellationCache();
+    Task<bool> ClearRegionCache();
+    Task<bool> ClearStargateCache();
+    Task<bool> ClearGroupCache();
+    Task<bool> ClearWormholeCache();
+    Task<bool> ClearSunCache();
+}

--- a/src/WHMapper/Services/EveMapper/IEveMapperHelper.cs
+++ b/src/WHMapper/Services/EveMapper/IEveMapperHelper.cs
@@ -5,16 +5,18 @@ using WHMapper.Models.DTO.EveMapper.Enums;
 using WHMapper.Models.Db;
 using WHMapper.Models.DTO.EveAPI.Universe;
 using WHMapper.Models.DTO.EveMapper;
+using WHMapper.Models.DTO.EveMapper.EveEntity;
 
 namespace WHMapper.Services.EveMapper
 {
 	public interface IEveMapperHelper
 	{
-        public ReadOnlyCollection<WormholeType> WormholeTypes { get; }
-        public Task<EveSystemNodeModel> DefineEveSystemNodeModel(WHSystem wh);
-        public bool IsWorhmole(string systemName);
-        public Task<EveSystemType> GetWHClass(ESISolarSystem whSystem);
-        public Task<EveSystemType> GetWHClass(string regionName, string constellationName, string systemName,float securityStatus);
+        ReadOnlyCollection<WormholeType> WormholeTypes { get; }
+        Task<EveSystemNodeModel> DefineEveSystemNodeModel(WHSystem wh);
+        bool IsWorhmole(string systemName);
+        Task<EveSystemType> GetWHClass(SystemEntity whSystem);
+        Task<EveSystemType> GetWHClass(string regionName, string constellationName, string systemName,float securityStatus);
+        Task<bool> IsRouteViaWH(SystemEntity src, SystemEntity dst);
     }
 }
 

--- a/src/WHMapper/Services/EveMapper/IEveMapperTracker.cs
+++ b/src/WHMapper/Services/EveMapper/IEveMapperTracker.cs
@@ -1,11 +1,12 @@
 ﻿using WHMapper.Models.DTO.EveAPI.Location;
 using WHMapper.Models.DTO.EveAPI.Universe;
+using WHMapper.Models.DTO.EveMapper.EveEntity;
 
 namespace WHMapper;
 
 public interface IEveMapperTracker
-{   event Func<ESISolarSystem, Task> SystemChanged;
-    event Func<Ship,WHMapper.Models.DTO.EveAPI.Universe.Type,Task> ShipChanged;
+{   event Func<SystemEntity, Task> SystemChanged;
+    event Func<Ship,ShipEntity,Task> ShipChanged;
 
     Task StartTracking();
     Task StopTracking();

--- a/src/WHMapper/Services/SDE/ISDEServices.cs
+++ b/src/WHMapper/Services/SDE/ISDEServices.cs
@@ -5,6 +5,9 @@ namespace WHMapper.Services.SDE
 {
 	public interface ISDEServices
 	{
+		const string REDIS_SOLAR_SYSTEM_JUMPS_KEY = "solarysystemjumps:list";
+        const string REDIS_SDE_SOLAR_SYSTEMS_KEY = "solarsystems:list";
+
 		bool ExtractSuccess {get; }
 		Task<bool> IsNewSDEAvailable();
     

--- a/src/WHMapper/Services/SDE/SDEServices.cs
+++ b/src/WHMapper/Services/SDE/SDEServices.cs
@@ -22,9 +22,6 @@ namespace WHMapper.Services.SDE
         private const string SDE_WORMHOLE_TARGET_DIRECTORY = @"./Resources/SDE/universe/sde/fsd/universe/wormhole";
         private const string SDE_DEFAULT_SOLARSYSTEM_STATIC_FILEMANE = "solarsystem.staticdata";
 
-        private const string REDIS_SOLAR_SYSTEM_JUMPS_KEY = "solarysystemjumps:list";
-        private const string REDIS_SDE_SOLAR_SYSTEMS_KEY = "solarsystems:list";
-
         private readonly ILogger _logger;
         private readonly ParallelOptions _options;
         private readonly IDeserializer _deserializer;
@@ -181,8 +178,8 @@ namespace WHMapper.Services.SDE
         {
             try
             {
-                await _cacheService.Remove(REDIS_SDE_SOLAR_SYSTEMS_KEY);
-                await _cacheService.Remove(REDIS_SOLAR_SYSTEM_JUMPS_KEY);
+                await _cacheService.Remove(ISDEServices.REDIS_SDE_SOLAR_SYSTEMS_KEY);
+                await _cacheService.Remove(ISDEServices.REDIS_SOLAR_SYSTEM_JUMPS_KEY);
 
                 return true;
             }
@@ -261,8 +258,8 @@ namespace WHMapper.Services.SDE
 
                     //clean old cache and add new one
                     await ClearCache();
-                    await _cacheService.Set(REDIS_SDE_SOLAR_SYSTEMS_KEY, SDESystems);
-                    await _cacheService.Set(REDIS_SOLAR_SYSTEM_JUMPS_KEY, tmp);
+                    await _cacheService.Set(ISDEServices.REDIS_SDE_SOLAR_SYSTEMS_KEY, SDESystems);
+                    await _cacheService.Set(ISDEServices.REDIS_SOLAR_SYSTEM_JUMPS_KEY, tmp);
 
                     return true;
                 }
@@ -283,7 +280,7 @@ namespace WHMapper.Services.SDE
         {
             try
             {
-                IEnumerable<SDESolarSystem>? results = await _cacheService.Get<IEnumerable<SDESolarSystem>?>(REDIS_SDE_SOLAR_SYSTEMS_KEY);
+                IEnumerable<SDESolarSystem>? results = await _cacheService.Get<IEnumerable<SDESolarSystem>?>(ISDEServices.REDIS_SDE_SOLAR_SYSTEMS_KEY);
                 if (results == null)
                     return new List<SDESolarSystem>();
                 return results;
@@ -299,7 +296,7 @@ namespace WHMapper.Services.SDE
         {
             try
             {
-                IEnumerable<SolarSystemJump>? results = await _cacheService.Get<IEnumerable<SolarSystemJump>?>(REDIS_SOLAR_SYSTEM_JUMPS_KEY);
+                IEnumerable<SolarSystemJump>? results = await _cacheService.Get<IEnumerable<SolarSystemJump>?>(ISDEServices.REDIS_SOLAR_SYSTEM_JUMPS_KEY);
                 if (results == null)
                     return new List<SolarSystemJump>();
 


### PR DESCRIPTION
This pull request adds caching functionality to the codebase in order to reduce the number of requests made to the ESI API. It includes the following changes:

- Added a new server to retrieve EveEntity from the ESI API only if they are not already present in the cache.

- Built a cache based on the usage of EveEntity.

- Added dedicated tests for the caching functionality.

- Optimized the code to ensure that API calls take less time compared to cache calls.

These changes improve the performance of the application by reducing the number of API requests and utilizing the cache effectively.