### PR TITLE
Fix : bug #356

### DIFF
--- a/src/WHMapper/Components/Pages/Mapper/Administration/Access/Overview.razor
+++ b/src/WHMapper/Components/Pages/Mapper/Administration/Access/Overview.razor
@@ -47,7 +47,7 @@
                             AdornmentIcon="@Icons.Material.Filled.Search" 
                             AdornmentColor="Color.Primary" 
                             ToStringFunc="@(x=> x==null ? null : $"{x.Name}")" 
-                            MaxItems="100">
+                            MaxItems=null>
                             <ItemTemplate Context="item">
                                 <MudText>
                                     @if (item.EntityType == EveEntityEnums.Alliance)
@@ -108,7 +108,7 @@
                                         Required="true" ResetValueOnEmptyText="true" CoerceValue="true" CoerceText="true"
                                         Validation="@(new Func<string, IEnumerable<string>>(EveMapperSearch.ValidateSearchType))"
                                         AdornmentIcon="@Icons.Material.Filled.Search" AdornmentColor="Color.Primary" 
-                                        ToStringFunc="@(x=> x==null?null : $"{x.Name}")" MaxItems="100">
+                                        ToStringFunc="@(x=> x==null?null : $"{x.Name}")" MaxItems=null>
                             <ItemTemplate Context="item">
                                 <MudText>
                                     <MudIcon Icon="@Icons.Material.Filled.Person" Class="mb-n1 mr-3" />

--- a/src/WHMapper/Components/Pages/Mapper/Search/SearchSystem.razor
+++ b/src/WHMapper/Components/Pages/Mapper/Search/SearchSystem.razor
@@ -10,7 +10,7 @@
                 AdornmentIcon="@Icons.Material.Filled.Search" 
                 AdornmentColor="Color.Primary" 
                 ToStringFunc="@(x=> x==null?null : $"{x.Name}")" 
-                MinCharacters="@Services.EveMapper.IEveMapperSearch.MIN_SEARCH_SYSTEM_CHARACTERS" />
+                MinCharacters="@Services.EveMapper.IEveMapperSearch.MIN_SEARCH_SYSTEM_CHARACTERS" MaxItems=null />
         </MudForm>
     </DialogContent>
     <DialogActions>


### PR DESCRIPTION
Fix: set MaxItems to null for MudAutocomplete SearchSystem components
Fix : set MaxItems to null to ignore the maximum number of items to display (default : 10)