### PR TITLE
feat: Add alternate name functionality for wormholes

### DIFF
--- a/src/WHMapper.Tests/Services/Db/DbIntegrationTest.cs
+++ b/src/WHMapper.Tests/Services/Db/DbIntegrationTest.cs
@@ -234,10 +234,12 @@ public class DbIntegrationTest
         //update
         result1.Name = FOOBAR_UPDATED;
         result1.SecurityStatus = 0.5F;
+        result1.AlternateName = FOOBAR_SHORT_UPDATED;
         var resultUpdate = await repo.Update(result1.Id, result1);
         Assert.NotNull(resultUpdate);
         Assert.Equal(FOOBAR_UPDATED, resultUpdate?.Name);
         Assert.Equal(0.5F, resultUpdate?.SecurityStatus);
+        Assert.Equal(FOOBAR_SHORT_UPDATED, resultUpdate?.AlternateName);
 
         //update duplicate
         Assert.NotNull(result2);

--- a/src/WHMapper.Tests/WHHelper/EveWHMapperHelperTest.cs
+++ b/src/WHMapper.Tests/WHHelper/EveWHMapperHelperTest.cs
@@ -235,6 +235,11 @@ public class EveWHMapperHelperTest
         Assert.Equal(SOLAR_SYSTEM_WH_CLASS, wh_result.SystemType);
         Assert.NotEqual(WHEffect.None, wh_result.Effect);
         Assert.Equal(SOLAR_SYSTEM_WH_EFFECT, wh_result.Effect);
+        Assert.Null(wh_result.AlternateName);
+
+        wh_result.SetAlternateName("J165153-1");
+        Assert.Equal("J165153-1", wh_result.AlternateName);
+        Assert.Throws<ArgumentOutOfRangeException>(() => wh_result.SetAlternateName("ABCDEFGHGHIJKLMNOPQRSTUVWXYZABCDEFGGHIJKLMNOPQRSTUVWXYZABCDEFGGHIJKLMNOPQRSTUVWXYZABCDEFGIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFG"));
     }
 
     [Fact, Priority(4)]

--- a/src/WHMapper.Tests/WHMapper.Tests.csproj
+++ b/src/WHMapper.Tests/WHMapper.Tests.csproj
@@ -12,16 +12,16 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.0.14" />
     <PackageReference Include="Testably.Abstractions.Compression" Version="4.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.17">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/WHMapper/Components/Pages/Mapper/CustomNode/EveSystemNode.razor
+++ b/src/WHMapper/Components/Pages/Mapper/CustomNode/EveSystemNode.razor
@@ -11,7 +11,30 @@
             </MudBadge>
         </CardHeaderAvatar>
         <CardHeaderContent>
-            <MudText class="ml-n1 pr-2 mt-1" Typo="Typo.body2" Style="font-weight:bold;">@Node.Name</MudText>
+            @if (_isEditingName)
+            {
+                <MudTextField @bind-Value="_editedName"
+                      Immediate="true"
+                      @onblur="@(() => SaveName())"
+                      @onkeyup="@((e) => OnKeyUp(e))"
+                      Class="ml-n1 pr-2 mt-1"
+                      Style="font-weight:bold; width: 120px;"
+                      Variant="Variant.Outlined"
+                      Margin="Margin.Dense"
+                      AutoFocus="true" />
+            }
+            else
+            {   
+                @if(Node.AlternateName!=null)
+                {
+                    <MudText class="ml-n1 pr-2 mt-1" Typo="Typo.body2" Style="font-weight:bold;" @ondblclick="StartEditingName">@Node.AlternateName</MudText>
+
+                }
+                else
+                {
+                    <MudText class="ml-n1 pr-2 mt-1" Typo="Typo.body2" Style="font-weight:bold;" @ondblclick="StartEditingName">@Node.Name</MudText>
+                }
+            }
         </CardHeaderContent>
         <CardHeaderActions>
             @if (Locked)

--- a/src/WHMapper/Components/Pages/Mapper/CustomNode/EveSystemNode.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/CustomNode/EveSystemNode.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using WHMapper.Models.Custom.Node;
 using WHMapper.Services.WHColor;
 
@@ -7,10 +8,12 @@ namespace WHMapper.Components.Pages.Mapper.CustomNode;
 
 public partial class EveSystemNode
 {
-
     private string _secColor = IWHColorHelper.DEFAULT_COLOR;
     private string _systemColor = IWHColorHelper.DEFAULT_COLOR;
     private string _whEffectColor = IWHColorHelper.DEFAULT_COLOR;
+
+    private bool _isEditingName = false;
+    private string? _editedName;
 
     [Inject]
     ILogger<EveSystemNode> Logger { get; set; } = null!;
@@ -19,8 +22,8 @@ public partial class EveSystemNode
     IWHColorHelper WHColorHelper { get; set; } = null!;
 
     [ParameterAttribute]
-    public EveSystemNodeModel Node {get;set;} = null!;
-    
+    public EveSystemNodeModel Node { get; set; } = null!;
+
     private bool Locked
     {
         get
@@ -32,7 +35,7 @@ public partial class EveSystemNode
         }
         set
         {
-            if(Node!=null)
+            if (Node != null)
             {
                 Node.Locked = value;
                 StateHasChanged();
@@ -50,10 +53,10 @@ public partial class EveSystemNode
             {
                 systemStyle += " box-shadow: 0px 0px 12px #fff;";
             }
-            
-            systemStyle += " border-color:"+WHColorHelper.GetNodeStatusColor(Node.SystemStatus)+";";
 
-            if(Node.IsRouteWaypoint)
+            systemStyle += " border-color:" + WHColorHelper.GetNodeStatusColor(Node.SystemStatus) + ";";
+
+            if (Node.IsRouteWaypoint)
             {
                 systemStyle += "border-style:dashed;border-color:yellow;";
             }
@@ -68,7 +71,7 @@ public partial class EveSystemNode
 
     protected override Task OnParametersSetAsync()
     {
-        if(Node!=null)
+        if (Node != null)
         {
             _secColor = WHColorHelper.GetSecurityStatusColor(Node.SecurityStatus);
             _systemColor = WHColorHelper.GetSystemTypeColor(Node.SystemType);
@@ -78,6 +81,48 @@ public partial class EveSystemNode
         }
 
         return base.OnParametersSetAsync();
+    }
+
+    private void StartEditingName()
+    {
+        _isEditingName = true;
+        if (Node.AlternateName != null)
+        {
+            _editedName = Node.AlternateName;
+        }
+        else
+        {
+            _editedName = Node.Name;
+        }
+        
+    }
+
+    private async Task SaveName()
+    {
+        if (string.IsNullOrWhiteSpace(_editedName) || (_editedName == Node.Name))
+        {
+            Node.SetAlternateName(null);
+        }
+        else if (_editedName != Node.Name)
+        {
+            Node.SetAlternateName(_editedName);
+        }
+
+        _isEditingName = false;
+        await InvokeAsync(StateHasChanged);
+    }
+    
+        private async Task OnKeyUp(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            await SaveName();
+        }
+        else if (e.Key == "Escape")
+        {
+            _isEditingName = false;
+            await InvokeAsync(StateHasChanged);
+        }
     }
 }
 

--- a/src/WHMapper/Hubs/IWHMapperNotificationHub.cs
+++ b/src/WHMapper/Hubs/IWHMapperNotificationHub.cs
@@ -17,6 +17,7 @@ namespace WHMapper.Hubs
         Task NotifyWormholeSignaturesChanged(int accountID, int mapId, int wormholeId);
         Task NotifyWormholeLockChanged(int accountID, int mapId, int wormholeId, bool locked);
         Task NotifyWormholeSystemStatusChanged(int accountID, int mapId, int wormholeId, WHSystemStatus systemStatus);
+        Task NotifyWormholeAlternateNameChanged(int accountID, int mapId, int wormholeId, string? alternateName);
         Task NotifyMapAdded(int accountID, int mapId);
         Task NotifyMapRemoved(int accountID, int mapId);
         Task NotifyMapNameChanged(int accountID, int mapId, string newName);

--- a/src/WHMapper/Hubs/WHMapperNotificationHub.cs
+++ b/src/WHMapper/Hubs/WHMapperNotificationHub.cs
@@ -177,10 +177,19 @@ public class WHMapperNotificationHub : Hub<IWHMapperNotificationHub>
             await Clients.AllExcept(Context.ConnectionId).NotifyWormholeSystemStatusChanged(accountID, mapId, wormholeId, systemStatus);
         }
     }
-
-    public Task<IDictionary<int,KeyValuePair<int,int>?>> GetConnectedUsersPosition()
+    
+    public async Task SendWormholeAlternateNameChanged(int mapId, int wormholeId, string? alternateName)
     {
-        return Task.FromResult<IDictionary<int,KeyValuePair<int,int>?>>(_connectedUserPosition);
+        int accountID = CurrentAccountId();
+        if(accountID != 0)
+        {
+            await Clients.AllExcept(Context.ConnectionId).NotifyWormholeAlternateNameChanged(accountID, mapId, wormholeId, alternateName);
+        }
+    }
+
+    public Task<IDictionary<int, KeyValuePair<int, int>?>> GetConnectedUsersPosition()
+    {
+        return Task.FromResult<IDictionary<int, KeyValuePair<int, int>?>>(_connectedUserPosition);
     }
 
     public async Task SendMapAdded(int mapId)

--- a/src/WHMapper/Migrations/20250626204448_Add_WHSystem_AlternateName.Designer.cs
+++ b/src/WHMapper/Migrations/20250626204448_Add_WHSystem_AlternateName.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WHMapper.Data;
@@ -11,9 +12,11 @@ using WHMapper.Data;
 namespace WHMapper.Migrations
 {
     [DbContext(typeof(WHMapperContext))]
-    partial class WHMapperContextModelSnapshot : ModelSnapshot
+    [Migration("20250626204448_Add_WHSystem_AlternateName")]
+    partial class Add_WHSystem_AlternateName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WHMapper/Migrations/20250626204448_Add_WHSystem_AlternateName.cs
+++ b/src/WHMapper/Migrations/20250626204448_Add_WHSystem_AlternateName.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WHMapper.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_WHSystem_AlternateName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AlternateName",
+                table: "Systems",
+                type: "character varying(255)",
+                maxLength: 255,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AlternateName",
+                table: "Systems");
+        }
+    }
+}

--- a/src/WHMapper/Models/Custom/Node/EveSystemNodeModel.cs
+++ b/src/WHMapper/Models/Custom/Node/EveSystemNodeModel.cs
@@ -9,6 +9,9 @@ namespace WHMapper.Models.Custom.Node
 {
     public class EveSystemNodeModel : NodeModel
     {
+        private const string NameExtensionErrorMessage = "Name extension must be between A and Z";
+        private const string AlternateNameErrorMessage = "Alternate name is too long. Maximum length is 255 characters.";
+
         public event Action<EveSystemNodeModel>? OnLocked;
         public event Action<EveSystemNodeModel>? OnSystemStatusChanged;
         public event Action<EveSystemNodeModel>? OnAlternateNameChanged;
@@ -206,7 +209,7 @@ namespace WHMapper.Models.Custom.Node
             if(c == null)
                 _wh.NameExtension = 0;
             else if (c < 'A' || c > 'Z')
-                throw new ArgumentOutOfRangeException("Name extension must be between A and Z");
+                throw new ArgumentOutOfRangeException(nameof(c), NameExtensionErrorMessage);
             else
                 _wh.NameExtension = Convert.ToByte(c);
         }
@@ -214,7 +217,7 @@ namespace WHMapper.Models.Custom.Node
         public void SetAlternateName(string? alternateName)
         {
             if (alternateName != null && alternateName.Length > 255)
-                throw new ArgumentOutOfRangeException("Alternate name is too long. Maximum length is 255 characters.");
+                throw new ArgumentOutOfRangeException(nameof(alternateName), AlternateNameErrorMessage);
             _wh.AlternateName = alternateName;
             OnAlternateNameChanged?.Invoke(this);
         }

--- a/src/WHMapper/Models/Custom/Node/EveSystemNodeModel.cs
+++ b/src/WHMapper/Models/Custom/Node/EveSystemNodeModel.cs
@@ -11,6 +11,7 @@ namespace WHMapper.Models.Custom.Node
     {
         public event Action<EveSystemNodeModel>? OnLocked;
         public event Action<EveSystemNodeModel>? OnSystemStatusChanged;
+        public event Action<EveSystemNodeModel>? OnAlternateNameChanged;
 
         private readonly WHSystem _wh;
         
@@ -41,12 +42,22 @@ namespace WHMapper.Models.Custom.Node
                 return _wh.Name;
             }
          }
+         
+        public String? AlternateName
+        {
+            get
+            {
+                if (_wh.AlternateName != null && _wh.AlternateName.Length > 0)
+                    return _wh.AlternateName;
+                return null;
+            }
+        }
 
         public String? NameExtension
         {
             get
             {
-                if(_wh!=null && _wh.NameExtension!=0)
+                if (_wh != null && _wh.NameExtension != 0)
                     return Convert.ToChar(_wh.NameExtension).ToString();
                 return null;
             }
@@ -200,6 +211,13 @@ namespace WHMapper.Models.Custom.Node
                 _wh.NameExtension = Convert.ToByte(c);
         }
 
+        public void SetAlternateName(string? alternateName)
+        {
+            if (alternateName != null && alternateName.Length > 255)
+                throw new ArgumentOutOfRangeException("Alternate name is too long. Maximum length is 255 characters.");
+            _wh.AlternateName = alternateName;
+            OnAlternateNameChanged?.Invoke(this);
+        }
 
         public async Task AddConnectedUser(string userName)
         {

--- a/src/WHMapper/Models/Db/WHSystem.cs
+++ b/src/WHMapper/Models/Db/WHSystem.cs
@@ -15,13 +15,16 @@ namespace WHMapper.Models.Db
         [Required]
         public int SoloarSystemId { get; set; } = -1;
 
-        [Required , StringLength(255, ErrorMessage = "Map name is too long.")]
+        [Required, StringLength(255, ErrorMessage = "Map name is too long.")]
         public String Name { get; set; } = string.Empty;
+
+        [StringLength(255, ErrorMessage = "Alternate name is too long.")]
+        public String? AlternateName { get; set; } = null;
 
         public byte NameExtension { get; set; }
 
         [Required]
-        public float SecurityStatus { get;  set; }
+        public float SecurityStatus { get; set; }
 
         public virtual ICollection<WHSignature> WHSignatures { get; } = new HashSet<WHSignature>();
 
@@ -33,7 +36,7 @@ namespace WHMapper.Models.Db
 
         [Obsolete("EF Requires it")]
         protected WHSystem() { }
-        public WHSystem(int whMapId,int solarSystemId,string name, float securityStatus,double posX, double posY)
+        public WHSystem(int whMapId, int solarSystemId, string name, float securityStatus, double posX, double posY)
         {
             WHMapId = whMapId;
             SoloarSystemId = solarSystemId;
@@ -56,15 +59,17 @@ namespace WHMapper.Models.Db
 
 
         public WHSystem(int whMapId, int solarSystemId, string name, float securityStatus) :
-            this(whMapId,solarSystemId, name, securityStatus, 0, 0)
+            this(whMapId, solarSystemId, name, securityStatus, 0, 0)
         {
         }
 
         public WHSystem(int whMapId, int solarSystemId, string name, char nameExtension, float securityStatus) :
-            this(whMapId,solarSystemId, name, nameExtension,securityStatus,0,0)
+            this(whMapId, solarSystemId, name, nameExtension, securityStatus, 0, 0)
         {
 
         }
+        
+        
 
     }
 }

--- a/src/WHMapper/Services/EveMapper/IEveMapperRealTimeService.cs
+++ b/src/WHMapper/Services/EveMapper/IEveMapperRealTimeService.cs
@@ -123,6 +123,15 @@ public interface IEveMapperRealTimeService : IAsyncDisposable
     event Func<int, int, int, WHSystemStatus, Task> WormholeSystemStatusChanged;
 
     /// <summary>
+    /// Triggered when a wormhole alternate name is changed.
+    /// </summary>
+    /// <param name="accountID">The accountID of the user who changed the wormhole alternate name.</param>
+    /// <param name="mapId">The ID of the map where the wormhole alternate name was changed.</param>
+    /// <param name="wormholeId">The ID of the wormhole with the changed alternate name.</param>
+    /// <param name="alternateName">The new alternate name of the wormhole, or null if removed.</param>
+    event Func<int, int,int, string?, Task> WormholeAlternateNameChanged;
+
+    /// <summary>
     /// Triggered when a map is added.
     /// </summary>
     /// <param name="accountID">The accountID of the user who added the map.</param>
@@ -301,6 +310,17 @@ public interface IEveMapperRealTimeService : IAsyncDisposable
     /// <param name="systemStatus">The new system status of the wormhole.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyWormholeSystemStatusChanged(int accountID, int mapId, int wormholeId, WHSystemStatus systemStatus);
+
+
+    /// <summary>
+    /// Notifies the server that an alternate name has been changed.
+    /// </summary>
+    /// <param name="accountID">The ID of the account.</param>
+    /// <param name="mapId">The ID of the map where the alternate name was changed.</param>
+    /// <param name="wormholeId">The ID of the wormhole with the changed alternate name.</param>
+    /// <param name="alternateName">The new alternate name of the wormhole, or null if removed.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task NotifyAlternameNameChanged(int accountID, int mapId, int wormholeId, string? alternateName);
 
     /// <summary>
     /// Gets the position of connected users.

--- a/src/WHMapper/WHMapper.csproj
+++ b/src/WHMapper/WHMapper.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
     <PackageReference Include="MudBlazor" Version="8.6.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
@@ -22,20 +22,20 @@
     <PackageReference Include="Z.Blazor.Diagrams" Version="3.0.2" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="FluentValidation" Version="12.*" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.10.*" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.16" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.17" />
     <PackageReference Include="FibonacciHeap" Version="2.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
     <PackageReference Include="Npgsql" Version="8.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.10.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="8.0.16" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="8.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.0" />
     <PackageReference Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.2" />
   </ItemGroup>


### PR DESCRIPTION
- Introduced a new method NotifyWormholeAlternateNameChanged in IWHMapperNotificationHub to notify clients of alternate name changes.
- Implemented SendWormholeAlternateNameChanged in WHMapperNotificationHub to handle alternate name notifications.
- Added an AlternateName property to WHSystem model with a maximum length of 255 characters.
- Created SetAlternateName method in EveSystemNodeModel to set and validate the alternate name.
- Updated EveMapperRealTimeService to handle WormholeAlternateNameChanged event and NotifyAlternameNameChanged method.
- Added migration to include AlternateName column in the Systems table.