### PR TITLE
feat: Add user settings management

### DIFF
--- a/src/WHMapper.Tests/Services/Db/DbIntegrationTest.cs
+++ b/src/WHMapper.Tests/Services/Db/DbIntegrationTest.cs
@@ -1639,6 +1639,10 @@ public class DbIntegrationTest
         var resultBadUpdate = await repo.Update(-10, result1);
         Assert.Null(resultBadUpdate);
 
+        // Null item update
+        var resultNullUpdate = await repo.Update(result1.Id, null!);
+        Assert.Null(resultNullUpdate);
+
         // DeleteById
         var resultDel1 = await repo.DeleteById(result1.Id);
         Assert.True(resultDel1);

--- a/src/WHMapper.Tests/Services/Db/DbIntegrationTest.cs
+++ b/src/WHMapper.Tests/Services/Db/DbIntegrationTest.cs
@@ -13,6 +13,7 @@ using WHMapper.Repositories.WHSignatures;
 using WHMapper.Repositories.WHSystemLinks;
 using WHMapper.Repositories.WHSystems;
 using WHMapper.Repositories.WHMapAccesses;
+using WHMapper.Repositories.WHUserSettings;
 
 using Xunit.Priority;
 
@@ -1560,5 +1561,101 @@ public class DbIntegrationTest
 
         //clean map
         var mapDeleted = await repoMap.DeleteById(map.Id);
+    }
+
+    [Fact, Priority(11)]
+    public async Task CRUD_WHUserSetting()
+    {
+        Assert.NotNull(_contextFactory);
+
+        IWHUserSettingRepository repo = new WHUserSettingRepository(new NullLogger<WHUserSettingRepository>(), _contextFactory);
+
+        // GetAll => empty
+        var resEmpty = await repo.GetAll();
+        Assert.NotNull(resEmpty);
+        Assert.Empty(resEmpty);
+
+        // Create
+        var result1 = await repo.Create(new WHUserSetting(EVE_CHARACTERE_ID));
+        Assert.NotNull(result1);
+        Assert.Equal(EVE_CHARACTERE_ID, result1!.EveCharacterId);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_LINK, result1.KeyLink);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_DELETE, result1.KeyDelete);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_INCREMENT_EXTENSION, result1.KeyIncrementExtension);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_DECREMENT_EXTENSION, result1.KeyDecrementExtension);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_INCREMENT_EXTENSION_ALT, result1.KeyIncrementExtensionAlt);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_DECREMENT_EXTENSION_ALT, result1.KeyDecrementExtensionAlt);
+        Assert.Equal(WHUserSetting.DEFAULT_ZOOM_ENABLED, result1.ZoomEnabled);
+        Assert.Equal(WHUserSetting.DEFAULT_ZOOM_INVERSE, result1.ZoomInverse);
+        Assert.Equal(WHUserSetting.DEFAULT_ALLOW_MULTI_SELECTION, result1.AllowMultiSelection);
+        Assert.Equal(WHUserSetting.DEFAULT_LINK_SNAPPING, result1.LinkSnapping);
+        Assert.Equal(WHUserSetting.DEFAULT_NODE_SPACING, result1.NodeSpacing);
+        Assert.Equal(WHUserSetting.DEFAULT_DRAG_THRESHOLD, result1.DragThreshold);
+
+        var result2 = await repo.Create(new WHUserSetting(EVE_CHARACTERE_ID2));
+        Assert.NotNull(result2);
+        Assert.Equal(EVE_CHARACTERE_ID2, result2!.EveCharacterId);
+
+        // Duplicate character create
+        var resultDuplicate = await repo.Create(new WHUserSetting(EVE_CHARACTERE_ID));
+        Assert.Null(resultDuplicate);
+
+        // GetCountAsync
+        var count = await repo.GetCountAsync();
+        Assert.Equal(2, count);
+
+        // GetAll
+        var results = await repo.GetAll();
+        Assert.NotNull(results);
+        Assert.Equal(2, results!.Count());
+
+        // GetById
+        var resultById1 = await repo.GetById(result1.Id);
+        Assert.NotNull(resultById1);
+        Assert.Equal(result1.Id, resultById1!.Id);
+
+        var resultBadById = await repo.GetById(-10);
+        Assert.Null(resultBadById);
+
+        // GetByCharacterId
+        var resultByChar = await repo.GetByCharacterId(EVE_CHARACTERE_ID);
+        Assert.NotNull(resultByChar);
+        Assert.Equal(EVE_CHARACTERE_ID, resultByChar!.EveCharacterId);
+
+        var resultBadByChar = await repo.GetByCharacterId(0);
+        Assert.Null(resultBadByChar);
+
+        // Update
+        result1.KeyLink = "KeyM";
+        result1.ZoomEnabled = false;
+        result1.NodeSpacing = 50;
+        var resultUpdate = await repo.Update(result1.Id, result1);
+        Assert.NotNull(resultUpdate);
+        Assert.Equal("KeyM", resultUpdate!.KeyLink);
+        Assert.False(resultUpdate.ZoomEnabled);
+        Assert.Equal(50, resultUpdate.NodeSpacing);
+
+        // Bad update (wrong id)
+        var resultBadUpdate = await repo.Update(-10, result1);
+        Assert.Null(resultBadUpdate);
+
+        // DeleteById
+        var resultDel1 = await repo.DeleteById(result1.Id);
+        Assert.True(resultDel1);
+
+        var resultBadDel = await repo.DeleteById(-10);
+        Assert.False(resultBadDel);
+
+        // DeleteByCharacterId
+        var resultDelByChar = await repo.DeleteByCharacterId(EVE_CHARACTERE_ID2);
+        Assert.True(resultDelByChar);
+
+        var resultBadDelByChar = await repo.DeleteByCharacterId(0);
+        Assert.False(resultBadDelByChar);
+
+        // Verify empty again
+        var resFinal = await repo.GetAll();
+        Assert.NotNull(resFinal);
+        Assert.Empty(resFinal);
     }
 }

--- a/src/WHMapper.Tests/Services/WHUserSettings/WHUserSettingServiceTests.cs
+++ b/src/WHMapper.Tests/Services/WHUserSettings/WHUserSettingServiceTests.cs
@@ -1,0 +1,150 @@
+using AutoFixture.Xunit2;
+using Moq;
+using WHMapper.Models.Db;
+using WHMapper.Repositories.WHUserSettings;
+using WHMapper.Services.WHUserSettings;
+
+namespace WHMapper.Tests.Services.WHUserSettings;
+
+public class WHUserSettingServiceTests
+{
+    private const int CHARACTER_ID = 2113720458;
+
+    [Theory, AutoMoqData]
+    public async Task GetSettingsAsync_WhenSettingsExist_ReturnsExistingSettings(
+        WHUserSetting existingSettings,
+        [Frozen] Mock<IWHUserSettingRepository> repoMock,
+        WHUserSettingService sut)
+    {
+        repoMock.Setup(r => r.GetByCharacterId(existingSettings.EveCharacterId))
+                .ReturnsAsync(existingSettings);
+
+        var result = await sut.GetSettingsAsync(existingSettings.EveCharacterId);
+
+        Assert.Equal(existingSettings, result);
+    }
+
+    [Theory, AutoMoqData]
+    public async Task GetSettingsAsync_WhenNoSettings_ReturnsDefaults(
+        [Frozen] Mock<IWHUserSettingRepository> repoMock,
+        WHUserSettingService sut)
+    {
+        repoMock.Setup(r => r.GetByCharacterId(CHARACTER_ID))
+                .ReturnsAsync((WHUserSetting?)null);
+
+        var result = await sut.GetSettingsAsync(CHARACTER_ID);
+
+        Assert.NotNull(result);
+        Assert.Equal(CHARACTER_ID, result.EveCharacterId);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_LINK, result.KeyLink);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_DELETE, result.KeyDelete);
+        Assert.Equal(WHUserSetting.DEFAULT_ZOOM_ENABLED, result.ZoomEnabled);
+        Assert.Equal(WHUserSetting.DEFAULT_NODE_SPACING, result.NodeSpacing);
+        Assert.Equal(WHUserSetting.DEFAULT_DRAG_THRESHOLD, result.DragThreshold);
+    }
+
+    [Theory, AutoMoqData]
+    public async Task SaveSettingsAsync_WhenExistingRecord_UpdatesAndFiresEvent(
+        WHUserSetting incoming,
+        WHUserSetting existing,
+        WHUserSetting updated,
+        [Frozen] Mock<IWHUserSettingRepository> repoMock,
+        WHUserSettingService sut)
+    {
+        repoMock.Setup(r => r.GetByCharacterId(incoming.EveCharacterId))
+                .ReturnsAsync(existing);
+        repoMock.Setup(r => r.Update(existing.Id, incoming))
+                .ReturnsAsync(updated);
+
+        WHUserSetting? eventArgs = null;
+        sut.OnSettingsChanged += s => { eventArgs = s; return Task.CompletedTask; };
+
+        var result = await sut.SaveSettingsAsync(incoming);
+
+        Assert.Equal(updated, result);
+        Assert.Equal(updated, eventArgs);
+        repoMock.Verify(r => r.Update(existing.Id, incoming), Times.Once);
+        repoMock.Verify(r => r.Create(It.IsAny<WHUserSetting>()), Times.Never);
+    }
+
+    [Theory, AutoMoqData]
+    public async Task SaveSettingsAsync_WhenNoExistingRecord_CreatesAndFiresEvent(
+        WHUserSetting incoming,
+        WHUserSetting created,
+        [Frozen] Mock<IWHUserSettingRepository> repoMock,
+        WHUserSettingService sut)
+    {
+        repoMock.Setup(r => r.GetByCharacterId(incoming.EveCharacterId))
+                .ReturnsAsync((WHUserSetting?)null);
+        repoMock.Setup(r => r.Create(incoming))
+                .ReturnsAsync(created);
+
+        WHUserSetting? eventArgs = null;
+        sut.OnSettingsChanged += s => { eventArgs = s; return Task.CompletedTask; };
+
+        var result = await sut.SaveSettingsAsync(incoming);
+
+        Assert.Equal(created, result);
+        Assert.Equal(created, eventArgs);
+        repoMock.Verify(r => r.Create(incoming), Times.Once);
+        repoMock.Verify(r => r.Update(It.IsAny<int>(), It.IsAny<WHUserSetting>()), Times.Never);
+    }
+
+    [Theory, AutoMoqData]
+    public async Task SaveSettingsAsync_WhenSaveFails_ReturnsNullAndNoEvent(
+        WHUserSetting incoming,
+        [Frozen] Mock<IWHUserSettingRepository> repoMock,
+        WHUserSettingService sut)
+    {
+        repoMock.Setup(r => r.GetByCharacterId(incoming.EveCharacterId))
+                .ReturnsAsync((WHUserSetting?)null);
+        repoMock.Setup(r => r.Create(incoming))
+                .ReturnsAsync((WHUserSetting?)null);
+
+        bool eventFired = false;
+        sut.OnSettingsChanged += _ => { eventFired = true; return Task.CompletedTask; };
+
+        var result = await sut.SaveSettingsAsync(incoming);
+
+        Assert.Null(result);
+        Assert.False(eventFired);
+    }
+
+    [Theory, AutoMoqData]
+    public async Task ResetToDefaultsAsync_WhenDeleted_ReturnsTrueAndFiresEventWithDefaults(
+        [Frozen] Mock<IWHUserSettingRepository> repoMock,
+        WHUserSettingService sut)
+    {
+        repoMock.Setup(r => r.DeleteByCharacterId(CHARACTER_ID))
+                .ReturnsAsync(true);
+
+        WHUserSetting? eventArgs = null;
+        sut.OnSettingsChanged += s => { eventArgs = s; return Task.CompletedTask; };
+
+        var result = await sut.ResetToDefaultsAsync(CHARACTER_ID);
+
+        Assert.True(result);
+        Assert.NotNull(eventArgs);
+        Assert.Equal(CHARACTER_ID, eventArgs.EveCharacterId);
+        Assert.Equal(WHUserSetting.DEFAULT_KEY_LINK, eventArgs.KeyLink);
+        Assert.Equal(WHUserSetting.DEFAULT_ZOOM_ENABLED, eventArgs.ZoomEnabled);
+        Assert.Equal(WHUserSetting.DEFAULT_NODE_SPACING, eventArgs.NodeSpacing);
+    }
+
+    [Theory, AutoMoqData]
+    public async Task ResetToDefaultsAsync_WhenNotDeleted_ReturnsFalseAndNoEvent(
+        [Frozen] Mock<IWHUserSettingRepository> repoMock,
+        WHUserSettingService sut)
+    {
+        repoMock.Setup(r => r.DeleteByCharacterId(CHARACTER_ID))
+                .ReturnsAsync(false);
+
+        bool eventFired = false;
+        sut.OnSettingsChanged += _ => { eventFired = true; return Task.CompletedTask; };
+
+        var result = await sut.ResetToDefaultsAsync(CHARACTER_ID);
+
+        Assert.False(result);
+        Assert.False(eventFired);
+    }
+}

--- a/src/WHMapper/Components/Layout/AccessControl.razor
+++ b/src/WHMapper/Components/Layout/AccessControl.razor
@@ -1,4 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Antiforgery
+@using WHMapper.Components.Pages.Mapper.Setting
 @using WHMapper.Models.DTO
 @using WHMapper.Components.Pages.Instance
 @implements IDisposable
@@ -14,6 +15,7 @@
                         <MudMenuItem Icon="@Icons.Material.Filled.PersonAdd" IconColor="Color.Default" Href="@GetLoginUrl()">Add Account</MudMenuItem>
                         <MudMenuItem Icon="@Icons.Material.Filled.Dashboard" IconColor="Color.Default" OnClick="OpenInstancesDialog">My Instances</MudMenuItem>
                         <MudMenuItem Icon="@Icons.Material.Filled.AppRegistration" IconColor="Color.Default" OnClick="OpenCreateInstanceDialog">Create Instance</MudMenuItem>
+                        <MudMenuItem Icon="@Icons.Material.Filled.Settings" IconColor="Color.Default" OnClick="OpenUserSettingsDialog">Settings</MudMenuItem>
                         <MudForm action="authentication/logout" method="post">
                             <input type="hidden" name="__RequestVerificationToken" value="@_antiForgeryToken" /> 
                             <input type="hidden" name="ReturnUrl" value="/" />
@@ -31,6 +33,7 @@
                                 <MudMenuItem Icon="@Icons.Material.Filled.PersonAdd" IconColor="Color.Default" Href="@GetLoginUrl()">Add Account</MudMenuItem>
                                 <MudMenuItem Icon="@Icons.Material.Filled.Dashboard" IconColor="Color.Default" OnClick="OpenInstancesDialog">My Instances</MudMenuItem>
                                 <MudMenuItem Icon="@Icons.Material.Filled.AppRegistration" IconColor="Color.Default" OnClick="OpenCreateInstanceDialog">Create Instance</MudMenuItem>
+                                <MudMenuItem Icon="@Icons.Material.Filled.Settings" IconColor="Color.Default" OnClick="OpenUserSettingsDialog">Settings</MudMenuItem>
                                 <MudForm action="authentication/logout" method="post">
                                     <input type="hidden" name="__RequestVerificationToken" value="@_antiForgeryToken" /> 
                                     <input type="hidden" name="ReturnUrl" value="/" />
@@ -128,5 +131,18 @@
         };
 
         await DialogService.ShowAsync<RegisterInstanceDialog>("Create Instance", options);
+    }
+
+    private async Task OpenUserSettingsDialog()
+    {
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true,
+            CloseButton = true,
+            BackdropClick = true
+        };
+
+        await DialogService.ShowAsync<UserSettingsDialog>("Settings", options);
     }
 }

--- a/src/WHMapper/Components/Pages/Mapper/CustomDragMovablesBehavior.cs
+++ b/src/WHMapper/Components/Pages/Mapper/CustomDragMovablesBehavior.cs
@@ -8,15 +8,16 @@ namespace WHMapper.Components.Pages.Mapper
 {
     public class CustomDragMovablesBehavior : Behavior
     {
-        private const double DragThreshold = 5.0;
+        private readonly double DragThreshold;
         private readonly Dictionary<MovableModel, Point> _initialPositions;
         private double? _lastClientX;
         private double? _lastClientY;
         private bool _moved;
         private bool _dragStarted;
 
-        public CustomDragMovablesBehavior(Diagram diagram) : base(diagram)
+        public CustomDragMovablesBehavior(Diagram diagram, double dragThreshold = 5.0) : base(diagram)
         {
+            DragThreshold = dragThreshold;
             _initialPositions = new Dictionary<MovableModel, Point>();
             Diagram.PointerDown += OnPointerDown;
             Diagram.PointerMove += OnPointerMove;

--- a/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
@@ -22,6 +22,7 @@ using WHMapper.Models.DTO.EveMapper;
 using WHMapper.Models.DTO;
 using Microsoft.AspNetCore.Components.Web;
 using WHMapper.Components.Pages.Mapper.CustomNode;
+using WHMapper.Services.WHUserSettings;
 
 namespace WHMapper.Components.Pages.Mapper.Map;
 
@@ -103,6 +104,11 @@ public partial class Overview : IAsyncDisposable
     [Inject]
     private IEveMapperService eveMapperService { get; set; } = null!;
 
+    [Inject]
+    private IWHUserSettingService UserSettingService { get; set; } = null!;
+
+    private WHUserSetting _userSettings = WHUserSetting.CreateDefault(0);
+
 
     #region Repositories
     [Inject]
@@ -158,11 +164,17 @@ public partial class Overview : IAsyncDisposable
             throw new InvalidOperationException(UidNullOrEmptyMessage);
         }
 
-
+        // InitDiagram must run before the first await so _blazorDiagram is set before Blazor renders DiagramCanvas
         if (!await InitDiagram())
         {
             Snackbar?.Add("Map Initialization error", Severity.Error);
         }
+
+        // Load real user settings and apply to the already-created diagram
+        var primaryAccount = await GetPrimaryAccountAsync();
+        _userSettings = await UserSettingService.GetSettingsAsync(primaryAccount?.Id ?? 0);
+        ApplyUserSettingsToDiagram();
+        UserSettingService.OnSettingsChanged += OnUserSettingsChangedAsync;
 
         await base.OnInitializedAsync();
     }
@@ -321,6 +333,8 @@ public partial class Overview : IAsyncDisposable
         }
         _cts.Dispose();
 
+        UserSettingService.OnSettingsChanged -= OnUserSettingsChangedAsync;
+
         // Unsubscribe from TrackerServices events
         // Note: Do NOT dispose TrackerServices here - it's a scoped service managed by DI
         // and must remain active for the lifetime of the user session
@@ -451,12 +465,6 @@ public partial class Overview : IAsyncDisposable
             {
 
                 _blazorDiagram = new BlazorDiagram();
-                _blazorDiagram.UnregisterBehavior<DragMovablesBehavior>();
-                _blazorDiagram.RegisterBehavior(new CustomDragMovablesBehavior(_blazorDiagram));
-                _blazorDiagram.Options.Zoom.Enabled = true;
-                _blazorDiagram.Options.Zoom.Inverse = false;
-                _blazorDiagram.Options.Links.EnableSnapping = false;
-                _blazorDiagram.Options.AllowMultiSelection = true;
                 _blazorDiagram.RegisterComponent<EveSystemNodeModel, EveSystemNode>();
                 _blazorDiagram.RegisterComponent<EveSystemLinkModel, EveSystemLink>();
             }
@@ -476,6 +484,27 @@ public partial class Overview : IAsyncDisposable
             return Task.FromResult(false);
         }
     }
+
+    private void ApplyUserSettingsToDiagram()
+    {
+        if (_blazorDiagram == null) return;
+
+        _blazorDiagram.UnregisterBehavior<DragMovablesBehavior>();
+        _blazorDiagram.UnregisterBehavior<CustomDragMovablesBehavior>();
+        _blazorDiagram.RegisterBehavior(new CustomDragMovablesBehavior(_blazorDiagram, _userSettings?.DragThreshold ?? WHUserSetting.DEFAULT_DRAG_THRESHOLD));
+        _blazorDiagram.Options.Zoom.Enabled = _userSettings?.ZoomEnabled ?? WHUserSetting.DEFAULT_ZOOM_ENABLED;
+        _blazorDiagram.Options.Zoom.Inverse = _userSettings?.ZoomInverse ?? WHUserSetting.DEFAULT_ZOOM_INVERSE;
+        _blazorDiagram.Options.Links.EnableSnapping = _userSettings?.LinkSnapping ?? WHUserSetting.DEFAULT_LINK_SNAPPING;
+        _blazorDiagram.Options.AllowMultiSelection = _userSettings?.AllowMultiSelection ?? WHUserSetting.DEFAULT_ALLOW_MULTI_SELECTION;
+    }
+
+    private async Task OnUserSettingsChangedAsync(WHUserSetting newSettings)
+    {
+        _userSettings = newSettings;
+        ApplyUserSettingsToDiagram();
+        await InvokeAsync(StateHasChanged);
+    }
+
     private Task InitBlazorDiagramEvents()
     {
         if (_blazorDiagram == null)
@@ -680,7 +709,7 @@ public partial class Overview : IAsyncDisposable
     #region Diagram Keyboard Pressed
     private async Task<bool> HandleLinkSystemKey(Blazor.Diagrams.Core.Events.KeyboardEventArgs eventArgs)
     {
-        if (eventArgs.Code == "KeyL" && MapId.HasValue && _selectedSystemNodes != null && _selectedSystemNodes.Count == 2)
+        if (eventArgs.Code == (_userSettings?.KeyLink ?? WHUserSetting.DEFAULT_KEY_LINK) && MapId.HasValue && _selectedSystemNodes != null && _selectedSystemNodes.Count == 2)
         {
             if (await IsLinkExist(_selectedSystemNodes.ElementAt(0), _selectedSystemNodes.ElementAt(1)))
             {
@@ -706,9 +735,14 @@ public partial class Overview : IAsyncDisposable
 
     private async Task<bool> HandleIncrementOrDecrementExtensionKey(Blazor.Diagrams.Core.Events.KeyboardEventArgs eventArgs)
     {
-        if ((eventArgs.Code == "NumpadAdd" || eventArgs.Code == "NumpadSubtract" || eventArgs.Code == "ArrowUp" || eventArgs.Code == "ArrowDown") && MapId.HasValue && SelectedSystemNode != null)
+        var incKey = _userSettings?.KeyIncrementExtension ?? WHUserSetting.DEFAULT_KEY_INCREMENT_EXTENSION;
+        var decKey = _userSettings?.KeyDecrementExtension ?? WHUserSetting.DEFAULT_KEY_DECREMENT_EXTENSION;
+        var incAltKey = _userSettings?.KeyIncrementExtensionAlt ?? WHUserSetting.DEFAULT_KEY_INCREMENT_EXTENSION_ALT;
+        var decAltKey = _userSettings?.KeyDecrementExtensionAlt ?? WHUserSetting.DEFAULT_KEY_DECREMENT_EXTENSION_ALT;
+
+        if ((eventArgs.Code == incKey || eventArgs.Code == decKey || eventArgs.Code == incAltKey || eventArgs.Code == decAltKey) && MapId.HasValue && SelectedSystemNode != null)
         {
-            bool res = eventArgs.Code == "NumpadAdd" || eventArgs.Code == "ArrowUp"
+            bool res = eventArgs.Code == incKey || eventArgs.Code == incAltKey
                 ? await IncrementOrDecrementNodeExtensionNameOnMap(MapId.Value, SelectedSystemNode, true)
                 : await IncrementOrDecrementNodeExtensionNameOnMap(MapId.Value, SelectedSystemNode, false);
 
@@ -728,7 +762,7 @@ public partial class Overview : IAsyncDisposable
 
     private async Task<bool> HandleDeleteKey(Blazor.Diagrams.Core.Events.KeyboardEventArgs eventArgs)
     {
-        if (eventArgs.Code == "Delete")
+        if (eventArgs.Code == (_userSettings?.KeyDelete ?? WHUserSetting.DEFAULT_KEY_DELETE))
         {
             if (!MapId.HasValue)
             {

--- a/src/WHMapper/Components/Pages/Mapper/Setting/UserSettingsDialog.razor
+++ b/src/WHMapper/Components/Pages/Mapper/Setting/UserSettingsDialog.razor
@@ -1,0 +1,73 @@
+@using WHMapper.Models.Db
+
+<MudDialog>
+    <TitleContent>
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+            <MudIcon Icon="@Icons.Material.Filled.Settings" />
+            <MudText Typo="Typo.h6">Settings</MudText>
+        </MudStack>
+    </TitleContent>
+    <DialogContent>
+        @if (_settings == null)
+        {
+            <MudStack Justify="Justify.Center" AlignItems="AlignItems.Center" Class="pa-4">
+                <MudProgressCircular Indeterminate="true" Color="Color.Primary" />
+            </MudStack>
+        }
+        else
+        {
+        <MudTabs Elevation="0" Rounded="true" ApplyEffectsToContainer="true">
+            <MudTabPanel Text="Keyboard" Icon="@Icons.Material.Filled.Keyboard">
+                <MudStack Spacing="3">
+                    <MudText Typo="Typo.caption" Class="pa-1">Click on a field and press any key to change the binding.</MudText>
+                    <div @onkeydown="@((e) => OnKeyCaptured(e, nameof(WHUserSetting.KeyLink)))" @onkeydown:preventDefault>
+                        <MudTextField T="string" Label="Link Systems" Value="@_settings.KeyLink"
+                            ReadOnly="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Link" />
+                    </div>
+                    <div @onkeydown="@((e) => OnKeyCaptured(e, nameof(WHUserSetting.KeyDelete)))" @onkeydown:preventDefault>
+                        <MudTextField T="string" Label="Delete" Value="@_settings.KeyDelete"
+                            ReadOnly="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Delete" />
+                    </div>
+                    <div @onkeydown="@((e) => OnKeyCaptured(e, nameof(WHUserSetting.KeyIncrementExtension)))" @onkeydown:preventDefault>
+                        <MudTextField T="string" Label="Increment Extension" Value="@_settings.KeyIncrementExtension"
+                            ReadOnly="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Add" />
+                    </div>
+                    <div @onkeydown="@((e) => OnKeyCaptured(e, nameof(WHUserSetting.KeyDecrementExtension)))" @onkeydown:preventDefault>
+                        <MudTextField T="string" Label="Decrement Extension" Value="@_settings.KeyDecrementExtension"
+                            ReadOnly="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Remove" />
+                    </div>
+                    <div @onkeydown="@((e) => OnKeyCaptured(e, nameof(WHUserSetting.KeyIncrementExtensionAlt)))" @onkeydown:preventDefault>
+                        <MudTextField T="string" Label="Increment Extension (Alt)" Value="@_settings.KeyIncrementExtensionAlt"
+                            ReadOnly="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.KeyboardArrowUp" />
+                    </div>
+                    <div @onkeydown="@((e) => OnKeyCaptured(e, nameof(WHUserSetting.KeyDecrementExtensionAlt)))" @onkeydown:preventDefault>
+                        <MudTextField T="string" Label="Decrement Extension (Alt)" Value="@_settings.KeyDecrementExtensionAlt"
+                            ReadOnly="true" Variant="Variant.Outlined" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.KeyboardArrowDown" />
+                    </div>
+                </MudStack>
+            </MudTabPanel>
+            <MudTabPanel Text="Mouse / Zoom" Icon="@Icons.Material.Filled.Mouse">
+                <MudStack Spacing="3">
+                    <MudSwitch @bind-Value="_settings.ZoomEnabled" Label="@($"Zoom {(_settings.ZoomEnabled ? "Enabled" : "Disabled")}")" Color="@(_settings.ZoomEnabled ? Color.Success : Color.Error)" />
+                    <MudSwitch @bind-Value="_settings.ZoomInverse" Label="@($"Inverse Zoom Direction {(_settings.ZoomInverse ? "Enabled" : "Disabled")}")" Color="@(_settings.ZoomInverse ? Color.Success : Color.Error)" />
+                    <MudSwitch @bind-Value="_settings.AllowMultiSelection" Label="@($"Allow Multi-Selection (Ctrl+Click) {(_settings.AllowMultiSelection ? "Enabled" : "Disabled")}")" Color="@(_settings.AllowMultiSelection ? Color.Success : Color.Error)" />
+                    <MudSwitch @bind-Value="_settings.LinkSnapping" Label="@($"Link Snapping {(_settings.LinkSnapping ? "Enabled" : "Disabled")}")" Color="@(_settings.LinkSnapping ? Color.Success : Color.Error)" />
+                </MudStack>
+            </MudTabPanel>
+            <MudTabPanel Text="Map" Icon="@Icons.Material.Filled.Map">
+                <MudStack Spacing="3">
+                    <MudNumericField @bind-Value="_settings.NodeSpacing" Label="Node Spacing" Variant="Variant.Outlined"
+                        Min="10.0" Max="200.0" Step="5.0" Adornment="Adornment.End" AdornmentText="px" />
+                    <MudNumericField @bind-Value="_settings.DragThreshold" Label="Drag Threshold" Variant="Variant.Outlined"
+                        Min="1.0" Max="50.0" Step="1.0" Adornment="Adornment.End" AdornmentText="px" />
+                </MudStack>
+            </MudTabPanel>
+        </MudTabs>
+        }
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel" Variant="Variant.Text" Color="Color.Error">Cancel</MudButton>
+        <MudButton OnClick="ResetToDefaults" Variant="Variant.Text" Color="Color.Warning" StartIcon="@Icons.Material.Filled.RestartAlt">Reset</MudButton>
+        <MudButton OnClick="Save" Variant="Variant.Filled" Color="Color.Success" StartIcon="@Icons.Material.Filled.Save">Save</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/src/WHMapper/Components/Pages/Mapper/Setting/UserSettingsDialog.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Setting/UserSettingsDialog.razor.cs
@@ -1,0 +1,146 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using MudBlazor;
+using WHMapper.Models.Db;
+using WHMapper.Models.DTO;
+using WHMapper.Services.EveMapper;
+using WHMapper.Services.WHUserSettings;
+
+namespace WHMapper.Components.Pages.Mapper.Setting;
+
+public partial class UserSettingsDialog
+{
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = null!;
+
+    [Inject]
+    private ILogger<UserSettingsDialog> Logger { get; set; } = null!;
+
+    [Inject]
+    private ISnackbar Snackbar { get; set; } = null!;
+
+    [Inject]
+    private IWHUserSettingService SettingService { get; set; } = null!;
+
+    [Inject]
+    private IEveMapperUserManagementService UserManagement { get; set; } = null!;
+
+    [Inject]
+    private ClientUID UID { get; set; } = null!;
+
+    [Parameter]
+    public WHUserSetting? Settings { get; set; }
+
+    private WHUserSetting? _settings;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Settings != null)
+        {
+            _settings = CloneSettings(Settings);
+        }
+        else
+        {
+            var primaryAccount = await UserManagement.GetPrimaryAccountAsync(UID.ClientId ?? string.Empty);
+            var characterId = primaryAccount?.Id ?? 0;
+            var loaded = await SettingService.GetSettingsAsync(characterId);
+            _settings = CloneSettings(loaded);
+        }
+
+        await base.OnInitializedAsync();
+    }
+
+    private void OnKeyCaptured(KeyboardEventArgs e, string propertyName)
+    {
+        if (_settings == null) return;
+        var code = e.Code;
+        if (string.IsNullOrEmpty(code))
+            return;
+
+        switch (propertyName)
+        {
+            case nameof(WHUserSetting.KeyLink):
+                _settings.KeyLink = code;
+                break;
+            case nameof(WHUserSetting.KeyDelete):
+                _settings.KeyDelete = code;
+                break;
+            case nameof(WHUserSetting.KeyIncrementExtension):
+                _settings.KeyIncrementExtension = code;
+                break;
+            case nameof(WHUserSetting.KeyDecrementExtension):
+                _settings.KeyDecrementExtension = code;
+                break;
+            case nameof(WHUserSetting.KeyIncrementExtensionAlt):
+                _settings.KeyIncrementExtensionAlt = code;
+                break;
+            case nameof(WHUserSetting.KeyDecrementExtensionAlt):
+                _settings.KeyDecrementExtensionAlt = code;
+                break;
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task Save()
+    {
+        if (_settings == null) return;
+        try
+        {
+            var saved = await SettingService.SaveSettingsAsync(_settings);
+            if (saved != null)
+            {
+                Snackbar.Add("Settings saved", Severity.Success);
+                MudDialog.Close(DialogResult.Ok(saved));
+            }
+            else
+            {
+                Snackbar.Add("Failed to save settings", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error saving user settings");
+            Snackbar.Add("Error saving settings", Severity.Error);
+        }
+    }
+
+    private async Task ResetToDefaults()
+    {
+        if (_settings == null) return;
+        try
+        {
+            await SettingService.ResetToDefaultsAsync(_settings.EveCharacterId);
+            _settings = WHUserSetting.CreateDefault(_settings.EveCharacterId);
+            Snackbar.Add("Settings reset to defaults", Severity.Info);
+            MudDialog.Close(DialogResult.Ok(_settings));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resetting user settings");
+            Snackbar.Add("Error resetting settings", Severity.Error);
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private static WHUserSetting CloneSettings(WHUserSetting source)
+    {
+        return new WHUserSetting(source.EveCharacterId)
+        {
+            Id = source.Id,
+            KeyLink = source.KeyLink,
+            KeyDelete = source.KeyDelete,
+            KeyIncrementExtension = source.KeyIncrementExtension,
+            KeyDecrementExtension = source.KeyDecrementExtension,
+            KeyIncrementExtensionAlt = source.KeyIncrementExtensionAlt,
+            KeyDecrementExtensionAlt = source.KeyDecrementExtensionAlt,
+            ZoomEnabled = source.ZoomEnabled,
+            ZoomInverse = source.ZoomInverse,
+            AllowMultiSelection = source.AllowMultiSelection,
+            LinkSnapping = source.LinkSnapping,
+            NodeSpacing = source.NodeSpacing,
+            DragThreshold = source.DragThreshold,
+        };
+    }
+}

--- a/src/WHMapper/Data/WHMapperContext.cs
+++ b/src/WHMapper/Data/WHMapperContext.cs
@@ -19,6 +19,7 @@ namespace WHMapper.Data
         public DbSet<WHInstanceAdmin> DbWHInstanceAdmins { get; set; } = null!;
         public DbSet<WHInstanceAccess> DbWHInstanceAccesses { get; set; } = null!;
         public DbSet<WHMapAccess> DbWHMapAccesses { get; set; } = null!;
+        public DbSet<WHUserSetting> DbWHUserSettings { get; set; } = null!;
 
         public WHMapperContext(DbContextOptions<WHMapperContext> options) : base(options)
 		{
@@ -78,6 +79,9 @@ namespace WHMapper.Data
 
             modelBuilder.Entity<WHJumpLog>().ToTable("JumpLogs");
             modelBuilder.Entity<WHJumpLog>().HasIndex(x => new { x.CharacterId, x.JumpDate }).IsUnique(true);
+
+            modelBuilder.Entity<WHUserSetting>().ToTable("UserSettings");
+            modelBuilder.Entity<WHUserSetting>().HasIndex(x => x.EveCharacterId).IsUnique(true);
         }
     }
 }

--- a/src/WHMapper/Extensions/DatabaseExtensions.cs
+++ b/src/WHMapper/Extensions/DatabaseExtensions.cs
@@ -54,12 +54,12 @@ public static class DatabaseExtensions
             Environment.Exit(1);
         }
 
-        if (dbContext.Database.GetPendingMigrations().Any())
+        if ((await dbContext.Database.GetPendingMigrationsAsync()).Any())
         {
             logger.LogInformation("Migrating database...");
             try
             {
-                dbContext.Database.Migrate();
+                await dbContext.Database.MigrateAsync();
                 logger.LogInformation("Database migrated successfully.");
             }
             catch (Exception ex)

--- a/src/WHMapper/Extensions/MapperServiceExtensions.cs
+++ b/src/WHMapper/Extensions/MapperServiceExtensions.cs
@@ -7,12 +7,14 @@ using WHMapper.Repositories.WHNotes;
 using WHMapper.Repositories.WHSignatures;
 using WHMapper.Repositories.WHSystemLinks;
 using WHMapper.Repositories.WHSystems;
+using WHMapper.Repositories.WHUserSettings;
 using WHMapper.Services.BrowserClientIdProvider;
 using WHMapper.Services.BrowserClientIdProvider.Extension;
 using WHMapper.Services.EveMapper;
 using WHMapper.Services.WHColor;
 using WHMapper.Services.WHSignature;
 using WHMapper.Services.WHSignatures;
+using WHMapper.Services.WHUserSettings;
 
 namespace WHMapper.Extensions;
 
@@ -30,6 +32,7 @@ public static class MapperServiceExtensions
         services.AddScoped<IWHJumpLogRepository, WHJumpLogRepository>();
         services.AddScoped<IWHInstanceRepository, WHInstanceRepository>();
         services.AddScoped<IWHMapAccessRepository, WHMapAccessRepository>();
+        services.AddScoped<IWHUserSettingRepository, WHUserSettingRepository>();
 
         // Mapper services
         services.AddSingleton<IBrowserClientIdProvider, BrowserClientIdProvider>();
@@ -48,6 +51,7 @@ public static class MapperServiceExtensions
         services.AddScoped<IWHColorHelper, WHColorHelper>();
         services.AddScoped<IEveMapperRealTimeService, EveMapperRealTimeService>();
         services.AddScoped<IPasteServices, PasteServices>();
+        services.AddScoped<IWHUserSettingService, WHUserSettingService>();
 
         return services;
     }

--- a/src/WHMapper/Migrations/20260407201443_AddUserSettings.Designer.cs
+++ b/src/WHMapper/Migrations/20260407201443_AddUserSettings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WHMapper.Data;
@@ -11,9 +12,11 @@ using WHMapper.Data;
 namespace WHMapper.Migrations
 {
     [DbContext(typeof(WHMapperContext))]
-    partial class WHMapperContextModelSnapshot : ModelSnapshot
+    [Migration("20260407201443_AddUserSettings")]
+    partial class AddUserSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/WHMapper/Migrations/20260407201443_AddUserSettings.cs
+++ b/src/WHMapper/Migrations/20260407201443_AddUserSettings.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace WHMapper.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserSettings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EveCharacterId = table.Column<int>(type: "integer", nullable: false),
+                    KeyLink = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    KeyDelete = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    KeyIncrementExtension = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    KeyDecrementExtension = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    KeyIncrementExtensionAlt = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    KeyDecrementExtensionAlt = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    ZoomEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    ZoomInverse = table.Column<bool>(type: "boolean", nullable: false),
+                    AllowMultiSelection = table.Column<bool>(type: "boolean", nullable: false),
+                    LinkSnapping = table.Column<bool>(type: "boolean", nullable: false),
+                    NodeSpacing = table.Column<double>(type: "double precision", nullable: false),
+                    DragThreshold = table.Column<double>(type: "double precision", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSettings_EveCharacterId",
+                table: "UserSettings",
+                column: "EveCharacterId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserSettings");
+        }
+    }
+}

--- a/src/WHMapper/Models/Db/WHUserSetting.cs
+++ b/src/WHMapper/Models/Db/WHUserSetting.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace WHMapper.Models.Db
+{
+    public class WHUserSetting
+    {
+        // Default constants
+        public const string DEFAULT_KEY_LINK = "KeyL";
+        public const string DEFAULT_KEY_DELETE = "Delete";
+        public const string DEFAULT_KEY_INCREMENT_EXTENSION = "NumpadAdd";
+        public const string DEFAULT_KEY_DECREMENT_EXTENSION = "NumpadSubtract";
+        public const string DEFAULT_KEY_INCREMENT_EXTENSION_ALT = "ArrowUp";
+        public const string DEFAULT_KEY_DECREMENT_EXTENSION_ALT = "ArrowDown";
+        public const bool DEFAULT_ZOOM_ENABLED = true;
+        public const bool DEFAULT_ZOOM_INVERSE = false;
+        public const bool DEFAULT_ALLOW_MULTI_SELECTION = true;
+        public const bool DEFAULT_LINK_SNAPPING = false;
+        public const double DEFAULT_NODE_SPACING = 30;
+        public const double DEFAULT_DRAG_THRESHOLD = 5;
+
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        public int EveCharacterId { get; set; }
+
+        // Keyboard settings
+        [Required, StringLength(50)]
+        public string KeyLink { get; set; } = DEFAULT_KEY_LINK;
+
+        [Required, StringLength(50)]
+        public string KeyDelete { get; set; } = DEFAULT_KEY_DELETE;
+
+        [Required, StringLength(50)]
+        public string KeyIncrementExtension { get; set; } = DEFAULT_KEY_INCREMENT_EXTENSION;
+
+        [Required, StringLength(50)]
+        public string KeyDecrementExtension { get; set; } = DEFAULT_KEY_DECREMENT_EXTENSION;
+
+        [Required, StringLength(50)]
+        public string KeyIncrementExtensionAlt { get; set; } = DEFAULT_KEY_INCREMENT_EXTENSION_ALT;
+
+        [Required, StringLength(50)]
+        public string KeyDecrementExtensionAlt { get; set; } = DEFAULT_KEY_DECREMENT_EXTENSION_ALT;
+
+        // Mouse / Zoom settings
+        public bool ZoomEnabled { get; set; } = DEFAULT_ZOOM_ENABLED;
+        public bool ZoomInverse { get; set; } = DEFAULT_ZOOM_INVERSE;
+        public bool AllowMultiSelection { get; set; } = DEFAULT_ALLOW_MULTI_SELECTION;
+        public bool LinkSnapping { get; set; } = DEFAULT_LINK_SNAPPING;
+
+        // Map settings
+        public double NodeSpacing { get; set; } = DEFAULT_NODE_SPACING;
+        public double DragThreshold { get; set; } = DEFAULT_DRAG_THRESHOLD;
+
+        [Obsolete("EF Requires it")]
+        protected WHUserSetting() { }
+
+        public WHUserSetting(int eveCharacterId)
+        {
+            EveCharacterId = eveCharacterId;
+        }
+
+        public static WHUserSetting CreateDefault(int eveCharacterId)
+        {
+            return new WHUserSetting(eveCharacterId);
+        }
+    }
+}

--- a/src/WHMapper/Repositories/WHUserSettings/IWHUserSettingRepository.cs
+++ b/src/WHMapper/Repositories/WHUserSettings/IWHUserSettingRepository.cs
@@ -1,0 +1,10 @@
+using WHMapper.Models.Db;
+
+namespace WHMapper.Repositories.WHUserSettings
+{
+    public interface IWHUserSettingRepository : IDefaultRepository<WHUserSetting, int>
+    {
+        Task<WHUserSetting?> GetByCharacterId(int eveCharacterId);
+        Task<bool> DeleteByCharacterId(int eveCharacterId);
+    }
+}

--- a/src/WHMapper/Repositories/WHUserSettings/WHUserSettingRepository.cs
+++ b/src/WHMapper/Repositories/WHUserSettings/WHUserSettingRepository.cs
@@ -1,0 +1,112 @@
+using Microsoft.EntityFrameworkCore;
+using WHMapper.Data;
+using WHMapper.Models.Db;
+
+namespace WHMapper.Repositories.WHUserSettings
+{
+    public class WHUserSettingRepository : ADefaultRepository<WHMapperContext, WHUserSetting, int>, IWHUserSettingRepository
+    {
+        public WHUserSettingRepository(ILogger<WHUserSettingRepository> logger, IDbContextFactory<WHMapperContext> context)
+            : base(logger, context)
+        {
+        }
+
+        protected override async Task<WHUserSetting?> ACreate(WHUserSetting item)
+        {
+            using (var context = await _contextFactory.CreateDbContextAsync())
+            {
+                try
+                {
+                    await context.DbWHUserSettings.AddAsync(item);
+                    await context.SaveChangesAsync();
+                    return item;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Impossible to create WHUserSetting for character: {EveCharacterId}", item.EveCharacterId);
+                    return null;
+                }
+            }
+        }
+
+        protected override async Task<bool> ADeleteById(int id)
+        {
+            using (var context = await _contextFactory.CreateDbContextAsync())
+            {
+                int deleteRow = await context.DbWHUserSettings.Where(x => x.Id == id).ExecuteDeleteAsync();
+                return deleteRow > 0;
+            }
+        }
+
+        protected override async Task<IEnumerable<WHUserSetting>?> AGetAll()
+        {
+            using (var context = await _contextFactory.CreateDbContextAsync())
+            {
+                return await context.DbWHUserSettings.ToListAsync();
+            }
+        }
+
+        protected override async Task<WHUserSetting?> AGetById(int id)
+        {
+            using (var context = await _contextFactory.CreateDbContextAsync())
+            {
+                return await context.DbWHUserSettings.SingleOrDefaultAsync(x => x.Id == id);
+            }
+        }
+
+        protected override async Task<WHUserSetting?> AUpdate(int id, WHUserSetting item)
+        {
+            if (item == null)
+            {
+                _logger.LogError("Impossible to update WHUserSetting, item is null");
+                return null;
+            }
+
+            if (id != item.Id)
+            {
+                _logger.LogError("Impossible to update WHUserSetting, id is different from item.Id");
+                return null;
+            }
+
+            using (var context = await _contextFactory.CreateDbContextAsync())
+            {
+                try
+                {
+                    context.DbWHUserSettings.Update(item);
+                    await context.SaveChangesAsync();
+                    return item;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Impossible to update WHUserSetting for character: {EveCharacterId}", item.EveCharacterId);
+                    return null;
+                }
+            }
+        }
+
+        protected override async Task<int> AGetCountAsync()
+        {
+            using (var context = await _contextFactory.CreateDbContextAsync())
+            {
+                return await context.DbWHUserSettings.CountAsync();
+            }
+        }
+
+        public async Task<WHUserSetting?> GetByCharacterId(int eveCharacterId)
+        {
+            using (var context = await _contextFactory.CreateDbContextAsync())
+            {
+                return await context.DbWHUserSettings.SingleOrDefaultAsync(x => x.EveCharacterId == eveCharacterId);
+            }
+        }
+
+        public async Task<bool> DeleteByCharacterId(int eveCharacterId)
+        {
+            using (var context = await _contextFactory.CreateDbContextAsync())
+            {
+                int deleteRow = await context.DbWHUserSettings.Where(x => x.EveCharacterId == eveCharacterId).ExecuteDeleteAsync();
+                return deleteRow > 0;
+            }
+        }
+    }
+}

--- a/src/WHMapper/Services/EveMapper/EveMapperCacheService.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperCacheService.cs
@@ -99,17 +99,17 @@ public class EveMapperCacheService : IEveMapperCacheService
     {
         return typeof(T).Name switch
         {
-            "CharacterEntity" => TimeSpan.FromHours(1),
-            "CorporationEntity" => TimeSpan.FromHours(6),
-            "AllianceEntity" => TimeSpan.FromHours(6),
-            "ShipEntity" => TimeSpan.FromHours(24),
-            "SystemEntity" => TimeSpan.FromHours(24),
-            "ConstellationEntity" => TimeSpan.FromHours(24),
-            "RegionEntity" => TimeSpan.FromHours(24),
-            "StargateEntity" => TimeSpan.FromHours(24),
-            "GroupEntity" => TimeSpan.FromHours(24),
-            "WHEntity" => TimeSpan.FromHours(24),
-            "SunEntity" => TimeSpan.FromHours(24),
+            "CharacterEntity" => TimeSpan.FromDays(1),
+            "CorporationEntity" => TimeSpan.FromDays(1),
+            "AllianceEntity" => TimeSpan.FromDays(1),
+            "ShipEntity" => TimeSpan.FromDays(7),
+            "SystemEntity" => TimeSpan.FromDays(7),
+            "ConstellationEntity" => TimeSpan.FromDays(7),
+            "RegionEntity" => TimeSpan.FromDays(7),
+            "StargateEntity" => TimeSpan.FromDays(7),
+            "GroupEntity" => TimeSpan.FromDays(7),
+            "WHEntity" => TimeSpan.FromDays(7),
+            "SunEntity" => TimeSpan.FromDays(7),
             _ => TimeSpan.FromHours(1),
         };
     }

--- a/src/WHMapper/Services/WHUserSettings/IWHUserSettingService.cs
+++ b/src/WHMapper/Services/WHUserSettings/IWHUserSettingService.cs
@@ -1,0 +1,12 @@
+using WHMapper.Models.Db;
+
+namespace WHMapper.Services.WHUserSettings
+{
+    public interface IWHUserSettingService
+    {
+        event Func<WHUserSetting, Task>? OnSettingsChanged;
+        Task<WHUserSetting> GetSettingsAsync(int eveCharacterId);
+        Task<WHUserSetting?> SaveSettingsAsync(WHUserSetting settings);
+        Task<bool> ResetToDefaultsAsync(int eveCharacterId);
+    }
+}

--- a/src/WHMapper/Services/WHUserSettings/WHUserSettingService.cs
+++ b/src/WHMapper/Services/WHUserSettings/WHUserSettingService.cs
@@ -5,14 +5,12 @@ namespace WHMapper.Services.WHUserSettings
 {
     public class WHUserSettingService : IWHUserSettingService
     {
-        private readonly ILogger<WHUserSettingService> _logger;
         private readonly IWHUserSettingRepository _repository;
 
         public event Func<WHUserSetting, Task>? OnSettingsChanged;
 
-        public WHUserSettingService(ILogger<WHUserSettingService> logger, IWHUserSettingRepository repository)
+        public WHUserSettingService(IWHUserSettingRepository repository)
         {
-            _logger = logger;
             _repository = repository;
         }
 

--- a/src/WHMapper/Services/WHUserSettings/WHUserSettingService.cs
+++ b/src/WHMapper/Services/WHUserSettings/WHUserSettingService.cs
@@ -1,0 +1,53 @@
+using WHMapper.Models.Db;
+using WHMapper.Repositories.WHUserSettings;
+
+namespace WHMapper.Services.WHUserSettings
+{
+    public class WHUserSettingService : IWHUserSettingService
+    {
+        private readonly ILogger<WHUserSettingService> _logger;
+        private readonly IWHUserSettingRepository _repository;
+
+        public event Func<WHUserSetting, Task>? OnSettingsChanged;
+
+        public WHUserSettingService(ILogger<WHUserSettingService> logger, IWHUserSettingRepository repository)
+        {
+            _logger = logger;
+            _repository = repository;
+        }
+
+        public async Task<WHUserSetting> GetSettingsAsync(int eveCharacterId)
+        {
+            var settings = await _repository.GetByCharacterId(eveCharacterId);
+            return settings ?? WHUserSetting.CreateDefault(eveCharacterId);
+        }
+
+        public async Task<WHUserSetting?> SaveSettingsAsync(WHUserSetting settings)
+        {
+            var existing = await _repository.GetByCharacterId(settings.EveCharacterId);
+            WHUserSetting? result;
+            if (existing != null)
+            {
+                settings.Id = existing.Id;
+                result = await _repository.Update(existing.Id, settings);
+            }
+            else
+            {
+                result = await _repository.Create(settings);
+            }
+
+            if (result != null && OnSettingsChanged != null)
+                await OnSettingsChanged.Invoke(result);
+
+            return result;
+        }
+
+        public async Task<bool> ResetToDefaultsAsync(int eveCharacterId)
+        {
+            var deleted = await _repository.DeleteByCharacterId(eveCharacterId);
+            if (deleted && OnSettingsChanged != null)
+                await OnSettingsChanged.Invoke(WHUserSetting.CreateDefault(eveCharacterId));
+            return deleted;
+        }
+    }
+}


### PR DESCRIPTION
- Introduced WHUserSetting model to manage user-specific settings.
- Created IWHUserSettingRepository and WHUserSettingRepository for data access.
- Implemented IWHUserSettingService and WHUserSettingService for business logic.
- Added UserSettingsDialog component for user interface to modify settings.
- Updated MapperServiceExtensions to register new services.
- Created migration to add UserSettings table to the database.
- Adjusted cache expiration times in EveMapperCacheService.
- Updated WHMapperContextModelSnapshot to reflect new UserSettings entity.