### PR TITLE
fix: resolve concurrency races, TOCTOU and dispose safety issues

### DIFF
--- a/src/WHMapper.Tests/WHMapper.Tests.csproj
+++ b/src/WHMapper.Tests/WHMapper.Tests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.0" />
-    <PackageReference Include="Testably.Abstractions.Compression" Version="6.0.1" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
+    <PackageReference Include="Testably.Abstractions.Compression" Version="6.2.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -29,13 +29,13 @@
     <PackageReference Include="Npgsql" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.*" />
     <PackageReference Include="Xunit.Priority" Version="1.1.6" />
-    <PackageReference Include="OpenTelemetry" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="appsettings.json" Condition="'$(ExcludeConfigFilesFromBuildOutput)'!='true'">

--- a/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
@@ -1003,7 +1003,7 @@ public partial class Overview : IAsyncDisposable
     {
         if (_blazorDiagram == null || _blazorDiagram.Nodes == null || _blazorDiagram.Nodes.Count == 0)
         {
-            Logger.LogWarning("GetNodeBySolarSystemId, no node in diagram");
+            Logger.LogDebug("GetNodeBySolarSystemId, no node in diagram");
             return Task.FromResult(null as EveSystemNodeModel);
         }
         var res = _blazorDiagram.Nodes

--- a/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
@@ -1362,10 +1362,7 @@ public partial class Overview : IAsyncDisposable
         Ship? currentShip = null;
         ShipEntity? currentShipInfos = null;
 
-        if (_currentShips.ContainsKey(accountID))
-        {
-            _currentShips.TryGetValue(accountID, out currentShip);
-        }
+        _currentShips.TryGetValue(accountID, out currentShip);
 
         if (currentShip == null)
         {
@@ -1505,16 +1502,10 @@ public partial class Overview : IAsyncDisposable
     #endregion
 
     #region Tracker Events
-    private async Task OnShipChanged(int accountID, Ship? oldShip, Ship newShip)
+    private Task OnShipChanged(int accountID, Ship? oldShip, Ship newShip)
     {
-        if (_currentShips.ContainsKey(accountID))
-        {
-            while (!_currentShips.TryRemove(accountID, out _))
-                await Task.Delay(1);
-        }
-
-        while (!_currentShips.TryAdd(accountID, newShip))
-            await Task.Delay(1);
+        _currentShips.AddOrUpdate(accountID, newShip, (_, _) => newShip);
+        return Task.CompletedTask;
     }
 
     private async Task OnSystemChanged(int accountID, EveLocation? oldLocation, EveLocation newLocation)

--- a/src/WHMapper/Components/Pages/Mapper/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Overview.razor.cs
@@ -204,7 +204,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -246,6 +246,11 @@ public partial class Overview : IAsyncDisposable
         _semaphoreSlim.Dispose();
         GC.SuppressFinalize(this);
         return ValueTask.CompletedTask;
+    }
+
+    private void SafeReleaseSemaphore()
+    {
+        try { _semaphoreSlim.Release(); } catch (ObjectDisposedException) { }
     }
 
     private async Task<bool> InitRealTimeService()
@@ -309,7 +314,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
         
     }
@@ -333,7 +338,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -356,7 +361,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -380,7 +385,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -445,7 +450,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -489,7 +494,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -549,7 +554,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -580,7 +585,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -622,7 +627,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 
@@ -673,7 +678,7 @@ public partial class Overview : IAsyncDisposable
         }
         finally
         {
-            _semaphoreSlim.Release();
+            SafeReleaseSemaphore();
         }
     }
 

--- a/src/WHMapper/Services/EveAPI/EveOnlineAccessTokenHandler.cs
+++ b/src/WHMapper/Services/EveAPI/EveOnlineAccessTokenHandler.cs
@@ -27,12 +27,7 @@ namespace WHMapper.Services.EveAPI
                 throw new UnauthorizedAccessException("User ID is not found.");
             }
 
-            if (await _eveAPITokenProvider.IsTokenExpire(userId))
-            {
-                await _eveAPITokenProvider.RefreshAccessToken(userId);
-            }
-
-            var token = (await _eveAPITokenProvider.GetToken(userId))?.AccessToken;
+            var token = (await _eveAPITokenProvider.GetToken(userId, autoRefreshed: true))?.AccessToken;
             if (!string.IsNullOrEmpty(token))
             {
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);

--- a/src/WHMapper/Services/EveMapper/EveMapperRealTimeService.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperRealTimeService.cs
@@ -308,18 +308,27 @@ public class EveMapperRealTimeService : IEveMapperRealTimeService
         }
     }
 
-    private async Task<HubConnection?> GetHubConnection(int accountID)
+    private Task<HubConnection?> GetHubConnection(int accountID)
     {
-        HubConnection? hubConnection = null;
+        _hubConnection.TryGetValue(accountID, out var hubConnection);
+        return Task.FromResult(hubConnection);
+    }
 
-        if (!_hubConnection.ContainsKey(accountID))
-            return hubConnection;
-        
-
-        while (!_hubConnection.TryGetValue(accountID, out hubConnection))
-            await Task.Delay(1);
-
-        return hubConnection;
+    private async Task SendSafeAsync(int accountID, string methodName, params object?[] args)
+    {
+        if (_disposed) return;
+        HubConnection? hubConnection = await GetHubConnection(accountID);
+        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
+        {
+            try
+            {
+                await hubConnection.SendCoreAsync(methodName, args);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogDebug(ex, "Connection became inactive before {Method} could be sent for account {AccountId}", methodName, accountID);
+            }
+        }
     }
 
     public async Task<bool> Stop(int accountID)
@@ -350,120 +359,79 @@ public class EveMapperRealTimeService : IEveMapperRealTimeService
 
     public async Task NotifyUserPosition(int accountID,int mapId,int wormholeId)
     {
-        
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendUserPosition", mapId, wormholeId);
-        }
+        await SendSafeAsync(accountID, "SendUserPosition", mapId, wormholeId);
     }
 
     public async Task NotifyWormoleAdded(int accountID,int mapId, int wormholeId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendWormholeAdded", mapId, wormholeId);
-        }
+        await SendSafeAsync(accountID, "SendWormholeAdded", mapId, wormholeId);
     }
 
     public async Task NotifyWormholeRemoved(int accountID,int mapId, int wormholeId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendWormholeRemoved", mapId, wormholeId);
-        }
+        await SendSafeAsync(accountID, "SendWormholeRemoved", mapId, wormholeId);
     }
 
     public async Task NotifyLinkAdded(int accountID,int mapId, int linkId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendLinkAdded", mapId, linkId);
-        }
+        await SendSafeAsync(accountID, "SendLinkAdded", mapId, linkId);
     }
 
     public async Task NotifyLinkRemoved(int accountID,int mapId, int linkId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendLinkRemoved", mapId, linkId);
-        }
+        await SendSafeAsync(accountID, "SendLinkRemoved", mapId, linkId);
     }
 
     public async Task NotifyWormholeMoved(int accountID,int mapId, int wormholeId, double posX, double posY)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendWormholeMoved", mapId, wormholeId, posX, posY);
-        }
+        await SendSafeAsync(accountID, "SendWormholeMoved", mapId, wormholeId, posX, posY);
     }
 
     public async Task NotifyLinkChanged(int accountID,int mapId, int linkId, SystemLinkEolStatus eolStatus, SystemLinkSize size, SystemLinkMassStatus mass)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendLinkChanged", mapId, linkId, (int)eolStatus, size, (int)mass);
-        }
+        await SendSafeAsync(accountID, "SendLinkChanged", mapId, linkId, (int)eolStatus, size, (int)mass);
     }
 
     public async Task NotifyWormholeNameExtensionChanged(int accountID,int mapId, int wormholeId, char? extension)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendWormholeNameExtensionChanged", mapId, wormholeId, extension);
-        }
+        await SendSafeAsync(accountID, "SendWormholeNameExtensionChanged", mapId, wormholeId, extension);
     }
     
 
     public async Task NotifyWormholeSignaturesChanged(int accountID, int mapId, int wormholeId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendWormholeSignaturesChanged", mapId, wormholeId);
-        }
+        await SendSafeAsync(accountID, "SendWormholeSignaturesChanged", mapId, wormholeId);
     }
 
     public async Task NotifyWormholeLockChanged(int accountID,int mapId, int wormholeId, bool locked)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendWormholeLockChanged", mapId, wormholeId, locked);
-        }
+        await SendSafeAsync(accountID, "SendWormholeLockChanged", mapId, wormholeId, locked);
     }
 
     public async Task NotifyWormholeSystemStatusChanged(int accountID,int mapId, int wormholeId, WHSystemStatus systemStatus)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendWormholeSystemStatusChanged", mapId, wormholeId, systemStatus);
-        }
+        await SendSafeAsync(accountID, "SendWormholeSystemStatusChanged", mapId, wormholeId, systemStatus);
     }
 
     public async Task NotifyAlternameNameChanged(int accountID, int mapId, int wormholeId, string? alternateName)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendWormholeAlternateNameChanged", mapId, wormholeId, alternateName);
-        }
+        await SendSafeAsync(accountID, "SendWormholeAlternateNameChanged", mapId, wormholeId, alternateName);
     }
 
     public async Task<IDictionary<int, KeyValuePair<int, int>?>> GetConnectedUsersPosition(int accountID)
     {
+        if (_disposed) return new Dictionary<int, KeyValuePair<int, int>?>();
         HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null)
+        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
         {
-            return await hubConnection.InvokeAsync<IDictionary<int, KeyValuePair<int, int>?>>("GetConnectedUsersPosition");
+            try
+            {
+                return await hubConnection.InvokeAsync<IDictionary<int, KeyValuePair<int, int>?>>("GetConnectedUsersPosition");
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogDebug(ex, "Connection became inactive before GetConnectedUsersPosition could be invoked for account {AccountId}", accountID);
+            }
         }
 
         return new Dictionary<int, KeyValuePair<int, int>?>();
@@ -471,110 +439,62 @@ public class EveMapperRealTimeService : IEveMapperRealTimeService
 
     public async Task NotifyMapAdded(int accountID,int mapId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendMapAdded", mapId);
-        }
+        await SendSafeAsync(accountID, "SendMapAdded", mapId);
     }
 
     public async Task NotifyMapRemoved(int accountID,int mapId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendMapRemoved", mapId);
-        }
+        await SendSafeAsync(accountID, "SendMapRemoved", mapId);
     }
 
     public async Task NotifyMapNameChanged(int accountID,int mapId, string newName)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendMapNameChanged", mapId, newName);
-        }
+        await SendSafeAsync(accountID, "SendMapNameChanged", mapId, newName);
     }
 
     public async Task NotifyAllMapsRemoved(int accountID)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendAllMapsRemoved");
-        }
+        await SendSafeAsync(accountID, "SendAllMapsRemoved");
     }
 
     public async Task NotifyMapAccessesAdded(int accountID,int mapId, IEnumerable<int> accessIds)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendMapAccessesAdded", mapId, accessIds);
-        }
+        await SendSafeAsync(accountID, "SendMapAccessesAdded", mapId, accessIds);
     }
 
     public async Task NotifyMapAccessRemoved(int accountID,int mapId, int accessId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendMapAccessRemoved", mapId, accessId);
-        }
+        await SendSafeAsync(accountID, "SendMapAccessRemoved", mapId, accessId);
     }
 
     public async Task NotifyMapAllAccessesRemoved(int accountID,int mapId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendMapAllAccessesRemoved", mapId);
-        }
+        await SendSafeAsync(accountID, "SendMapAllAccessesRemoved", mapId);
     }
 
     public async Task NotifyUserOnMapConnected(int accountID,int mapId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendUserOnMapConnected", mapId);
-        }
+        await SendSafeAsync(accountID, "SendUserOnMapConnected", mapId);
     }
 
     public async Task NotifyUserOnMapDisconnected(int accountID,int mapId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendUserOnMapDisconnected", mapId);
-        }
+        await SendSafeAsync(accountID, "SendUserOnMapDisconnected", mapId);
     }
 
     public async Task NotifyInstanceAccessAdded(int accountID, int instanceId, int accessId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendInstanceAccessAdded", instanceId, accessId);
-        }
+        await SendSafeAsync(accountID, "SendInstanceAccessAdded", instanceId, accessId);
     }
 
     public async Task NotifyInstanceAccessRemoved(int accountID, int instanceId, int accessId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendInstanceAccessRemoved", instanceId, accessId);
-        }
+        await SendSafeAsync(accountID, "SendInstanceAccessRemoved", instanceId, accessId);
     }
 
     public async Task NotifyInstanceRemoved(int accountID, int instanceId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("SendInstanceRemoved", instanceId);
-        }
+        await SendSafeAsync(accountID, "SendInstanceRemoved", instanceId);
     }
 
     public async ValueTask DisposeAsync()
@@ -656,19 +576,11 @@ public class EveMapperRealTimeService : IEveMapperRealTimeService
 
     public async Task JoinMap(int accountID, int mapId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("JoinMap", mapId);
-        }
+        await SendSafeAsync(accountID, "JoinMap", mapId);
     }
 
     public async Task LeaveMap(int accountID, int mapId)
     {
-        HubConnection? hubConnection = await GetHubConnection(accountID);
-        if (hubConnection is not null && hubConnection.State == HubConnectionState.Connected)
-        {
-            await hubConnection.SendAsync("LeaveMap", mapId);
-        }
+        await SendSafeAsync(accountID, "LeaveMap", mapId);
     }
 }

--- a/src/WHMapper/Services/EveOAuthProvider/Services/EVEOnlineTokenProvider.cs
+++ b/src/WHMapper/Services/EveOAuthProvider/Services/EVEOnlineTokenProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using WHMapper.Models.DTO;
 using WHMapper.Models.DTO.EveAPI.SSO;
 
@@ -12,6 +13,7 @@ namespace WHMapper.Services.EveOAuthProvider.Services
     {
         private readonly EVEOnlineAuthenticationOptions _options;
         private readonly ConcurrentDictionary<string, UserToken> _tokens = new();
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _refreshLocks = new();
 
 
         public EveOnlineTokenProvider(IOptionsMonitor<EVEOnlineAuthenticationOptions> options)
@@ -30,10 +32,10 @@ namespace WHMapper.Services.EveOAuthProvider.Services
             return Task.CompletedTask;
         }
 
-        public async Task<UserToken?> GetToken(string accountId, bool autoResfred = false)
+        public async Task<UserToken?> GetToken(string accountId, bool autoRefreshed = false)
         {
             _tokens.TryGetValue(accountId, out var token);
-            if(autoResfred && token != null && await IsTokenExpire(token))
+            if(autoRefreshed && token != null && await IsTokenExpire(token))
             {
                 await RefreshAccessToken(accountId);
                 _tokens.TryGetValue(accountId, out token);
@@ -69,18 +71,33 @@ namespace WHMapper.Services.EveOAuthProvider.Services
 
         public async Task RefreshAccessToken(string accountId)
         {
+            var semaphore = _refreshLocks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
+            await semaphore.WaitAsync();
+            try
+            {
             var token = await GetToken(accountId);
             if (token == null)
             {
                 throw new NullReferenceException("Token is null");
             }
 
+            // Double-check: another thread may have already refreshed while we were waiting
+            if (!await IsTokenExpire(token))
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(token.RefreshToken))
+            {
+                throw new InvalidOperationException("Refresh token is missing.");
+            }
+
             var refreshToken = Uri.EscapeDataString(token.RefreshToken);
             var content = new StringContent($"grant_type=refresh_token&refresh_token={refreshToken}", Encoding.UTF8, "application/x-www-form-urlencoded");
 
-            _options.Backchannel.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_options.ClientId}:{_options.ClientSecret}")));
-            var response = await _options.Backchannel.PostAsync(_options.TokenEndpoint, content);
-            _options.Backchannel.DefaultRequestHeaders.Authorization=null;
+            var request = new HttpRequestMessage(HttpMethod.Post, _options.TokenEndpoint) { Content = content };
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_options.ClientId}:{_options.ClientSecret}")));
+            var response = await _options.Backchannel.SendAsync(request);
 
             response.EnsureSuccessStatusCode();
 
@@ -97,8 +114,11 @@ namespace WHMapper.Services.EveOAuthProvider.Services
             token.Expiry = DateTimeOffset.UtcNow.AddSeconds(newToken.ExpiresIn).UtcDateTime;
 
             await SaveToken(token);
-
-            
+            }
+            finally
+            {
+                semaphore.Release();
+            }
         }
 
         public async Task RevokeToken(string accountId)
@@ -109,12 +129,17 @@ namespace WHMapper.Services.EveOAuthProvider.Services
                 throw new NullReferenceException("Token is null");
             }
 
+            if (string.IsNullOrEmpty(token.RefreshToken))
+            {
+                throw new InvalidOperationException("Refresh token is missing.");
+            }
+
             var refreshToken = Uri.EscapeDataString(token.RefreshToken);
             var content = new StringContent($"token_type_hint=refresh_token&token={refreshToken}", Encoding.UTF8, "application/x-www-form-urlencoded");
 
-            _options.Backchannel.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_options.ClientId}:{_options.ClientSecret}")));
-            var response = await _options.Backchannel.PostAsync(_options.RevokeTokenEndpoint, content);
-            _options.Backchannel.DefaultRequestHeaders.Authorization=null;
+            var request = new HttpRequestMessage(HttpMethod.Post, _options.RevokeTokenEndpoint) { Content = content };
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($"{_options.ClientId}:{_options.ClientSecret}")));
+            var response = await _options.Backchannel.SendAsync(request);
             
             if (!response.IsSuccessStatusCode)
             {
@@ -127,7 +152,8 @@ namespace WHMapper.Services.EveOAuthProvider.Services
 
         private class ErrorResponse
         {
-            public string ErrorDescription { get; set; }
+            [JsonPropertyName("error_description")]
+            public string? ErrorDescription { get; set; }
         }
     }
 }

--- a/src/WHMapper/Services/EveOAuthProvider/Services/EVEOnlineTokenProvider.cs
+++ b/src/WHMapper/Services/EveOAuthProvider/Services/EVEOnlineTokenProvider.cs
@@ -66,6 +66,9 @@ namespace WHMapper.Services.EveOAuthProvider.Services
                 throw new NullReferenceException("Token is null");
             }
 
+            if (token.Expiry == default || token.Expiry == DateTime.MinValue)
+                return Task.FromResult(true);
+
             return Task.FromResult(DateTimeOffset.UtcNow > token.Expiry.AddMinutes(-5));//// 5 minutes before expiry
         }
 

--- a/src/WHMapper/Services/EveOAuthProvider/Services/IEveOnlineTokenProvider.cs
+++ b/src/WHMapper/Services/EveOAuthProvider/Services/IEveOnlineTokenProvider.cs
@@ -5,7 +5,7 @@ namespace WHMapper.Services.EveOAuthProvider.Services;
 public interface IEveOnlineTokenProvider
 {
     Task SaveToken(UserToken token);
-    Task<UserToken?> GetToken(string accountId,bool autoResfred = false);
+    Task<UserToken?> GetToken(string accountId, bool autoRefreshed = false);
     Task ClearToken(string accountId);
     Task<bool> IsTokenExpire(string accountId);
     Task RefreshAccessToken(string accountId);

--- a/src/WHMapper/WHMapper.csproj
+++ b/src/WHMapper/WHMapper.csproj
@@ -19,13 +19,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.*" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
-    <PackageReference Include="MudBlazor" Version="9.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageReference Include="MudBlazor" Version="9.4.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.*" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.*" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Z.Blazor.Diagrams" Version="3.0.4.1" />
-    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="YamlDotNet" Version="17.1.0" />
     <PackageReference Include="FluentValidation" Version="12.*" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.*" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.*" />
@@ -39,13 +39,13 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.*" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.*" />
     <PackageReference Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.4.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
EveMapperRealTimeService:
- Add SendSafeAsync helper (_disposed guard + State check + InvalidOperationException catch) to handle the TOCTOU race between State == Connected check and SendAsync execution
- Refactor all 27 send methods (Notify*, JoinMap, LeaveMap) to use it
- Fix GetConnectedUsersPosition: add _disposed guard, State check and try-catch (previously called InvokeAsync unconditionally)
- Fix GetHubConnection: replace ContainsKey + busy-wait TryGetValue with a single atomic TryGetValue (eliminates TOCTOU + potential infinite loop)

Mapper/Map/Overview.razor.cs:
- Fix AddSystemNodeLinkLog: replace ContainsKey + TryGetValue with direct TryGetValue (TOCTOU on ConcurrentDictionary)
- Fix OnShipChanged: replace ContainsKey + busy-wait TryRemove + busy-wait TryAdd with a single atomic AddOrUpdate

Mapper/Overview.razor.cs:
- Add SafeReleaseSemaphore() helper to absorb ObjectDisposedException when the component is disposed while an async event handler still holds the semaphore
- Apply SafeReleaseSemaphore() to all 11 finally blocks (OnPrimaryAccount- Changed, OnMapAdded/Removed/NameChanged/AllRemoved, OnMapAccessesAdded/ Removed/AllRemoved, OnInstanceAccessAdded/Removed/Removed)

EVEOnlineTokenProvider:
- Add per-account SemaphoreSlim to prevent concurrent token refreshes
- Add double-check after lock acquisition to skip redundant refreshes
- Replace shared DefaultRequestHeaders mutation with per-request Authorization header (thread-safe)
- Guard against null/empty RefreshToken in RefreshAccessToken and RevokeToken
- Fix ErrorResponse JSON deserialization (add JsonPropertyName attribute)
- Fix typo: autoResfred -> autoRefreshed

EveOnlineAccessTokenHandler:
- Simplify to single GetToken(autoRefreshed: true) call, removing redundant manual IsTokenExpire + RefreshAccessToken calls

IEveOnlineTokenProvider:
- Fix interface typo: autoResfred -> autoRefreshed

Co-authored-by: Copilot <copilot@github.com>