### PR TITLE
fix(security): enforce per-map access in SignalR hub and anchor authz…

### DIFF
--- a/src/WHMapper.Tests/Hubs/WHMapperNotificationHubTests.cs
+++ b/src/WHMapper.Tests/Hubs/WHMapperNotificationHubTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using WHMapper.Hubs;
+using WHMapper.Services.EveMapper;
 using WHMapper.Services.Metrics;
 
 namespace WHMapper.Tests.Hubs;
@@ -50,11 +51,20 @@ public class WHMapperNotificationHubTests : IDisposable
         var mapConnectionsField = hubType.GetField("_mapConnections", BindingFlags.NonPublic | BindingFlags.Static);
         var mapConnections = mapConnectionsField!.GetValue(null)!;
         mapConnections.GetType().GetMethod("Clear")!.Invoke(mapConnections, null);
+
+        var authorizedMapsField = hubType.GetField("_authorizedMaps", BindingFlags.NonPublic | BindingFlags.Static);
+        var authorizedMaps = authorizedMapsField!.GetValue(null)!;
+        authorizedMaps.GetType().GetMethod("Clear")!.Invoke(authorizedMaps, null);
     }
 
-    private WHMapperNotificationHub CreateHub(int accountId, string connectionId)
+    private WHMapperNotificationHub CreateHub(int accountId, string connectionId, bool mapAccessAuthorized = true)
     {
-        var hub = new WHMapperNotificationHub(_meters);
+        var accessHelperMock = new Mock<IEveMapperAccessHelper>();
+        accessHelperMock
+            .Setup(h => h.IsEveMapperMapAccessAuthorized(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(mapAccessAuthorized);
+
+        var hub = new WHMapperNotificationHub(_meters, accessHelperMock.Object);
 
         var contextMock = new Mock<HubCallerContext>();
         contextMock.Setup(c => c.UserIdentifier).Returns(accountId == 0 ? null : $"prefix:scheme:{accountId}");
@@ -66,6 +76,13 @@ public class WHMapperNotificationHubTests : IDisposable
         clientsMock.Setup(c => c.AllExcept(It.IsAny<IReadOnlyList<string>>())).Returns(notifTarget.Object);
         clientsMock.Setup(c => c.OthersInGroup(It.IsAny<string>())).Returns(notifTarget.Object);
         hub.Clients = clientsMock.Object;
+
+        var groupsMock = new Mock<IGroupManager>();
+        groupsMock.Setup(g => g.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        groupsMock.Setup(g => g.RemoveFromGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        hub.Groups = groupsMock.Object;
 
         return hub;
     }
@@ -233,6 +250,7 @@ public class WHMapperNotificationHubTests : IDisposable
     {
         var hub = CreateHub(accountId: 123, connectionId: "conn-1");
         await hub.OnConnectedAsync();
+        await hub.JoinMap(42);
 
         await hub.SendUserOnMapConnected(42);
 
@@ -246,6 +264,8 @@ public class WHMapperNotificationHubTests : IDisposable
         var hub2 = CreateHub(accountId: 123, connectionId: "conn-2");
         await hub1.OnConnectedAsync();
         await hub2.OnConnectedAsync();
+        await hub1.JoinMap(42);
+        await hub2.JoinMap(42);
 
         await hub1.SendUserOnMapConnected(42);
         await hub2.SendUserOnMapConnected(42);
@@ -260,6 +280,8 @@ public class WHMapperNotificationHubTests : IDisposable
         var hubB = CreateHub(accountId: 222, connectionId: "conn-B");
         await hubA.OnConnectedAsync();
         await hubB.OnConnectedAsync();
+        await hubA.JoinMap(42);
+        await hubB.JoinMap(42);
 
         await hubA.SendUserOnMapConnected(42);
         await hubB.SendUserOnMapConnected(42);
@@ -272,6 +294,7 @@ public class WHMapperNotificationHubTests : IDisposable
     {
         var hub = CreateHub(accountId: 123, connectionId: "conn-1");
         await hub.OnConnectedAsync();
+        await hub.JoinMap(42);
         await hub.SendUserOnMapConnected(42);
 
         await hub.SendUserOnMapDisconnected(42);
@@ -284,6 +307,7 @@ public class WHMapperNotificationHubTests : IDisposable
     {
         var hub = CreateHub(accountId: 123, connectionId: "conn-1");
         await hub.OnConnectedAsync();
+        await hub.JoinMap(42);
         await hub.SendUserOnMapConnected(42);
 
         await hub.OnDisconnectedAsync(null);
@@ -298,6 +322,8 @@ public class WHMapperNotificationHubTests : IDisposable
         var hub2 = CreateHub(accountId: 123, connectionId: "conn-2");
         await hub1.OnConnectedAsync();
         await hub2.OnConnectedAsync();
+        await hub1.JoinMap(42);
+        await hub2.JoinMap(42);
         await hub1.SendUserOnMapConnected(42);
         await hub2.SendUserOnMapConnected(42);
 
@@ -311,12 +337,39 @@ public class WHMapperNotificationHubTests : IDisposable
     {
         var hub = CreateHub(accountId: 123, connectionId: "conn-1");
         await hub.OnConnectedAsync();
+        await hub.JoinMap(42);
+        await hub.JoinMap(99);
 
         await hub.SendUserOnMapConnected(42);
         await hub.SendUserOnMapConnected(99);
 
         Assert.Equal(1, await hub.GetUserCountOnMap(42));
         Assert.Equal(1, await hub.GetUserCountOnMap(99));
+    }
+
+    [Fact]
+    public async Task JoinMap_AccessNotAuthorized_ThrowsAndDoesNotJoin()
+    {
+        var hub = CreateHub(accountId: 123, connectionId: "conn-1", mapAccessAuthorized: false);
+        await hub.OnConnectedAsync();
+
+        await Assert.ThrowsAsync<HubException>(() => hub.JoinMap(42));
+
+        // Presence updates from an unauthorized connection must be ignored.
+        await hub.SendUserOnMapConnected(42);
+        Assert.Equal(0, await hub.GetUserCountOnMap(42));
+    }
+
+    [Fact]
+    public async Task SendUserOnMapConnected_WithoutJoiningMap_IsIgnored()
+    {
+        var hub = CreateHub(accountId: 123, connectionId: "conn-1");
+        await hub.OnConnectedAsync();
+
+        // No JoinMap call -> connection was never authorized for this map.
+        await hub.SendUserOnMapConnected(42);
+
+        Assert.Equal(0, await hub.GetUserCountOnMap(42));
     }
 
     [Fact]

--- a/src/WHMapper.Tests/Hubs/WHMapperNotificationHubTests.cs
+++ b/src/WHMapper.Tests/Hubs/WHMapperNotificationHubTests.cs
@@ -55,14 +55,40 @@ public class WHMapperNotificationHubTests : IDisposable
         var authorizedMapsField = hubType.GetField("_authorizedMaps", BindingFlags.NonPublic | BindingFlags.Static);
         var authorizedMaps = authorizedMapsField!.GetValue(null)!;
         authorizedMaps.GetType().GetMethod("Clear")!.Invoke(authorizedMaps, null);
+
+        var authorizedInstancesField = hubType.GetField("_authorizedInstances", BindingFlags.NonPublic | BindingFlags.Static);
+        var authorizedInstances = authorizedInstancesField!.GetValue(null)!;
+        authorizedInstances.GetType().GetMethod("Clear")!.Invoke(authorizedInstances, null);
     }
 
-    private WHMapperNotificationHub CreateHub(int accountId, string connectionId, bool mapAccessAuthorized = true)
+    // Notification sink of the last hub built, so tests can assert what was broadcast.
+    private Mock<IWHMapperNotificationHub> _lastNotificationTarget = new();
+
+    private WHMapperNotificationHub CreateHub(
+        int accountId,
+        string connectionId,
+        bool mapAccessAuthorized = true,
+        bool instanceAccessAuthorized = true,
+        bool isInstanceAdmin = true,
+        IEnumerable<int>? accessibleInstanceIds = null,
+        int? mapInstanceId = 7)
     {
         var accessHelperMock = new Mock<IEveMapperAccessHelper>();
         accessHelperMock
             .Setup(h => h.IsEveMapperMapAccessAuthorized(It.IsAny<int>(), It.IsAny<int>()))
             .ReturnsAsync(mapAccessAuthorized);
+        accessHelperMock
+            .Setup(h => h.IsEveMapperInstanceAccessAuthorized(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(instanceAccessAuthorized);
+        accessHelperMock
+            .Setup(h => h.IsInstanceAdminAuthorized(It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync(isInstanceAdmin);
+        accessHelperMock
+            .Setup(h => h.GetAccessibleInstanceIdsAsync(It.IsAny<int>()))
+            .ReturnsAsync(accessibleInstanceIds ?? Array.Empty<int>());
+        accessHelperMock
+            .Setup(h => h.GetMapInstanceIdAsync(It.IsAny<int>()))
+            .ReturnsAsync(mapInstanceId);
 
         var hub = new WHMapperNotificationHub(_meters, accessHelperMock.Object);
 
@@ -72,9 +98,11 @@ public class WHMapperNotificationHubTests : IDisposable
         hub.Context = contextMock.Object;
 
         var notifTarget = new Mock<IWHMapperNotificationHub>();
+        _lastNotificationTarget = notifTarget;
         var clientsMock = new Mock<IHubCallerClients<IWHMapperNotificationHub>>();
         clientsMock.Setup(c => c.AllExcept(It.IsAny<IReadOnlyList<string>>())).Returns(notifTarget.Object);
         clientsMock.Setup(c => c.OthersInGroup(It.IsAny<string>())).Returns(notifTarget.Object);
+        clientsMock.Setup(c => c.Clients(It.IsAny<IReadOnlyList<string>>())).Returns(notifTarget.Object);
         hub.Clients = clientsMock.Object;
 
         var groupsMock = new Mock<IGroupManager>();
@@ -329,7 +357,9 @@ public class WHMapperNotificationHubTests : IDisposable
 
         await hub1.OnDisconnectedAsync(null);
 
-        Assert.Equal(1, await hub1.GetUserCountOnMap(42));
+        // Queried through the surviving connection: a disconnected connection loses its map
+        // authorization and can no longer read map-scoped counts.
+        Assert.Equal(1, await hub2.GetUserCountOnMap(42));
     }
 
     [Fact]
@@ -358,6 +388,130 @@ public class WHMapperNotificationHubTests : IDisposable
         // Presence updates from an unauthorized connection must be ignored.
         await hub.SendUserOnMapConnected(42);
         Assert.Equal(0, await hub.GetUserCountOnMap(42));
+    }
+
+    [Fact]
+    public async Task JoinInstance_AccessNotAuthorized_ThrowsAndDoesNotJoin()
+    {
+        var hub = CreateHub(accountId: 123, connectionId: "conn-1", instanceAccessAuthorized: false);
+        await hub.OnConnectedAsync();
+
+        await Assert.ThrowsAsync<HubException>(() => hub.JoinInstance(7));
+
+        // An unauthorized connection must not be able to broadcast into that instance either.
+        await hub.SendMapAdded(7, 42);
+        _lastNotificationTarget.Verify(t => t.NotifyMapAdded(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendMapAdded_WithoutJoiningInstance_IsIgnored()
+    {
+        var hub = CreateHub(accountId: 123, connectionId: "conn-1");
+        await hub.OnConnectedAsync();
+
+        // No JoinInstance/JoinMap call -> the connection was never authorized for instance 7.
+        await hub.SendMapAdded(7, 42);
+
+        _lastNotificationTarget.Verify(t => t.NotifyMapAdded(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendMapAccessRemoved_NotInstanceAdmin_IsIgnored()
+    {
+        var hub = CreateHub(accountId: 123, connectionId: "conn-1", isInstanceAdmin: false);
+        await hub.OnConnectedAsync();
+        await hub.JoinInstance(7);
+
+        await hub.SendMapAccessRemoved(7, 42, 5);
+
+        _lastNotificationTarget.Verify(
+            t => t.NotifyMapAccessRemoved(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SendMapAccessRemoved_InstanceAdmin_BroadcastsToInstanceGroup()
+    {
+        var hub = CreateHub(accountId: 123, connectionId: "conn-1");
+        await hub.OnConnectedAsync();
+        await hub.JoinInstance(7);
+
+        await hub.SendMapAccessRemoved(7, 42, 5);
+
+        _lastNotificationTarget.Verify(t => t.NotifyMapAccessRemoved(123, 42, 5), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendInstanceRemoved_NotAdminAtJoinTime_IsIgnored()
+    {
+        // Admin status is captured when joining; a plain member must not be able to forge the event.
+        var hub = CreateHub(accountId: 123, connectionId: "conn-1", isInstanceAdmin: false);
+        await hub.OnConnectedAsync();
+        await hub.JoinInstance(7);
+
+        await hub.SendInstanceRemoved(7);
+
+        _lastNotificationTarget.Verify(t => t.NotifyInstanceRemoved(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task JoinMap_AlsoJoinsOwningInstance()
+    {
+        var hub = CreateHub(accountId: 123, connectionId: "conn-1", mapInstanceId: 7);
+        await hub.OnConnectedAsync();
+        await hub.JoinMap(42);
+
+        // Instance membership was derived server-side from the map, so the broadcast goes through.
+        await hub.SendMapAccessRemoved(7, 42, 5);
+
+        _lastNotificationTarget.Verify(t => t.NotifyMapAccessRemoved(123, 42, 5), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetConnectedUsersPosition_ExcludesMapsTheConnectionCannotSee()
+    {
+        var owner = CreateHub(accountId: 123, connectionId: "conn-1");
+        await owner.OnConnectedAsync();
+        await owner.JoinMap(42);
+        await owner.SendUserPosition(42, 1000);
+
+        var stranger = CreateHub(accountId: 456, connectionId: "conn-2");
+        await stranger.OnConnectedAsync();
+        await stranger.JoinMap(99);
+
+        var visible = await stranger.GetConnectedUsersPosition();
+
+        Assert.DoesNotContain(123, visible.Keys);
+    }
+
+    [Fact]
+    public async Task GetConnectedUsersPosition_IncludesUsersOnASharedMap()
+    {
+        var owner = CreateHub(accountId: 123, connectionId: "conn-1");
+        await owner.OnConnectedAsync();
+        await owner.JoinMap(42);
+        await owner.SendUserPosition(42, 1000);
+
+        var peer = CreateHub(accountId: 456, connectionId: "conn-2");
+        await peer.OnConnectedAsync();
+        await peer.JoinMap(42);
+
+        var visible = await peer.GetConnectedUsersPosition();
+
+        Assert.Equal(new KeyValuePair<int, int>(42, 1000), visible[123]);
+    }
+
+    [Fact]
+    public async Task GetUserCountOnMap_WithoutJoiningMap_ReturnsZero()
+    {
+        var member = CreateHub(accountId: 123, connectionId: "conn-1");
+        await member.OnConnectedAsync();
+        await member.JoinMap(42);
+        await member.SendUserOnMapConnected(42);
+
+        var stranger = CreateHub(accountId: 456, connectionId: "conn-2");
+        await stranger.OnConnectedAsync();
+
+        Assert.Equal(0, await stranger.GetUserCountOnMap(42));
     }
 
     [Fact]

--- a/src/WHMapper.Tests/Models/ClientUIDTest.cs
+++ b/src/WHMapper.Tests/Models/ClientUIDTest.cs
@@ -8,10 +8,8 @@ public class ClientUIDTest
     [Fact]
     public void ClientUID_ShouldInitializeWithDefaultValues()
     {
-        // Arrange & Act
         var clientUID = new ClientUID();
 
-        // Assert
         Assert.NotNull(clientUID.ClientId);
         Assert.Equal(string.Empty, clientUID.ClientId);
     }
@@ -26,7 +24,6 @@ public class ClientUIDTest
         // Act
         clientUID.ClientId = testClientId;
 
-        // Assert
         Assert.Equal(testClientId, clientUID.ClientId);
     }
 
@@ -39,7 +36,6 @@ public class ClientUIDTest
         // Act
         clientUID.ClientId = null;
 
-        // Assert
         Assert.Null(clientUID.ClientId);
     }
 
@@ -52,7 +48,6 @@ public class ClientUIDTest
         // Act
         clientUID.ClientId = string.Empty;
 
-        // Assert
         Assert.Equal(string.Empty, clientUID.ClientId);
     }
 }

--- a/src/WHMapper.Tests/Models/Custom/Node/EveSystemLinkModelTest.cs
+++ b/src/WHMapper.Tests/Models/Custom/Node/EveSystemLinkModelTest.cs
@@ -40,7 +40,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             var linkModel = new EveSystemLinkModel(whLink, sourceNode, targetNode);
 
-            // Assert
             Assert.NotNull(linkModel.SourceMarker);
             Assert.NotNull(linkModel.TargetMarker);
             Assert.Single(linkModel.Labels);
@@ -58,7 +57,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             var result = linkModel.Id;
 
-            // Assert
             Assert.Equal(42, result);
         }
 
@@ -77,7 +75,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.EndOfLifeStatus = status;
 
-            // Assert
             Assert.Equal(status, linkModel.EndOfLifeStatus);
         }
 
@@ -121,7 +118,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.IsEoL = true;
 
-            // Assert
             Assert.Equal(SystemLinkEolStatus.EOL4h, linkModel.EndOfLifeStatus);
         }
 
@@ -137,7 +133,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.IsEoL = false;
 
-            // Assert
             Assert.Equal(SystemLinkEolStatus.Normal, linkModel.EndOfLifeStatus);
         }
 
@@ -153,7 +148,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.Size = SystemLinkSize.Small;
 
-            // Assert
             Assert.Equal(SystemLinkSize.Small, linkModel.Size);
             Assert.Single(linkModel.Labels);
             Assert.Equal("S", ((LinkLabelModel)linkModel.Labels[0]).Content);
@@ -171,7 +165,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.Size = SystemLinkSize.Medium;
 
-            // Assert
             Assert.Equal(SystemLinkSize.Medium, linkModel.Size);
             Assert.Single(linkModel.Labels);
             Assert.Equal("M", ((LinkLabelModel)linkModel.Labels[0]).Content);
@@ -189,7 +182,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.Size = SystemLinkSize.Large;
 
-            // Assert
             Assert.Equal(SystemLinkSize.Large, linkModel.Size);
             Assert.Empty(linkModel.Labels);
         }
@@ -206,7 +198,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.Size = SystemLinkSize.XLarge;
 
-            // Assert
             Assert.Equal(SystemLinkSize.XLarge, linkModel.Size);
             Assert.Single(linkModel.Labels);
             Assert.Equal("XL", ((LinkLabelModel)linkModel.Labels[0]).Content);
@@ -227,7 +218,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.MassStatus = status;
 
-            // Assert
             Assert.Equal(status, linkModel.MassStatus);
         }
 
@@ -240,7 +230,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             var targetNode = CreateNodeModel();
             var linkModel = new EveSystemLinkModel(whLink, sourceNode, targetNode);
 
-            // Assert
             Assert.False(linkModel.IsRouteWaypoint);
         }
 
@@ -256,7 +245,6 @@ namespace WHMapper.Tests.Models.Custom.Node
             // Act
             linkModel.IsRouteWaypoint = true;
 
-            // Assert
             Assert.True(linkModel.IsRouteWaypoint);
         }
     }

--- a/src/WHMapper.Tests/Models/DTO/EveAPI/Dogma/AttributeTest.cs
+++ b/src/WHMapper.Tests/Models/DTO/EveAPI/Dogma/AttributeTest.cs
@@ -9,10 +9,8 @@ public class AttributeTest
     [Fact]
     public void Constructor_ShouldInitializePropertiesWithDefaultValues()
     {
-        // Arrange & Act
         var attribute = new WHMapper.Models.DTO.EveAPI.Dogma.Attribute();
 
-        // Assert
         Assert.Equal(0, attribute.AttributeId);
         Assert.Equal(0f, attribute.DefaultValue);
         Assert.Equal(string.Empty, attribute.Description);
@@ -53,7 +51,6 @@ public class AttributeTest
         attribute.Stackable = stackable;
         attribute.UnitId = unitId;
 
-        // Assert
         Assert.Equal(attributeId, attribute.AttributeId);
         Assert.Equal(defaultValue, attribute.DefaultValue);
         Assert.Equal(description, attribute.Description);
@@ -88,7 +85,6 @@ public class AttributeTest
         var json = JsonSerializer.Serialize(attribute);
         var deserializedAttribute = JsonSerializer.Deserialize<WHMapper.Models.DTO.EveAPI.Dogma.Attribute>(json);
 
-        // Assert
         Assert.NotNull(deserializedAttribute);
         Assert.Equal(attribute.AttributeId, deserializedAttribute!.AttributeId);
         Assert.Equal(attribute.DefaultValue, deserializedAttribute.DefaultValue);

--- a/src/WHMapper.Tests/Models/DTO/EveAPI/Dogma/EffectTest.cs
+++ b/src/WHMapper.Tests/Models/DTO/EveAPI/Dogma/EffectTest.cs
@@ -9,10 +9,8 @@ public class EffectTest
     [Fact]
     public void Constructor_ShouldInitializePropertiesWithDefaultValues()
     {
-        // Arrange & Act
         var effect = new Effect();
 
-        // Assert
         Assert.Equal(string.Empty, effect.Description);
         Assert.False(effect.DisallowAutoRepeat);
         Assert.Equal(0, effect.DischargeAttributeId);
@@ -86,7 +84,6 @@ public class EffectTest
         effect.RangeChance = rangeChance;
         effect.TrackingSpeedAttributeId = trackingSpeedAttributeId;
 
-        // Assert
         Assert.Equal(description, effect.Description);
         Assert.True(effect.DisallowAutoRepeat);
         Assert.Equal(dischargeAttributeId, effect.DischargeAttributeId);
@@ -143,7 +140,6 @@ public class EffectTest
         var json = JsonSerializer.Serialize(effect);
         var deserializedEffect = JsonSerializer.Deserialize<Effect>(json);
 
-        // Assert
         Assert.NotNull(deserializedEffect);
         Assert.Equal(effect.Description, deserializedEffect!.Description);
         Assert.Equal(effect.DisallowAutoRepeat, deserializedEffect.DisallowAutoRepeat);

--- a/src/WHMapper.Tests/Models/MapAdminTests.cs
+++ b/src/WHMapper.Tests/Models/MapAdminTests.cs
@@ -21,7 +21,6 @@ public class MapAdminTests
         // Act
         var mapAdmin = new MapAdmin(whMap);
 
-        // Assert
         Assert.Equal(1, mapAdmin.Id);
         Assert.Equal("Test Map", mapAdmin.Name);
         Assert.NotNull(mapAdmin.WHMapAccesses);
@@ -33,9 +32,8 @@ public class MapAdminTests
     public void Constructor_ShouldHandleNullWHMap()
     {
         // Act
-        var mapAdmin = new MapAdmin(null);
+        var mapAdmin = new MapAdmin(null!);
 
-        // Assert
         Assert.Equal(-1, mapAdmin.Id);
         Assert.Equal(string.Empty, mapAdmin.Name);
         Assert.Null(mapAdmin.WHMapAccesses);
@@ -51,7 +49,6 @@ public class MapAdminTests
         // Act
         var mapAdmin = new MapAdmin(whMap);
 
-        // Assert
         Assert.False(mapAdmin.ShowAccessDetails);
     }
 
@@ -65,7 +62,6 @@ public class MapAdminTests
         // Act
         mapAdmin.ShowAccessDetails = true;
 
-        // Assert
         Assert.True(mapAdmin.ShowAccessDetails);
     }
 }

--- a/src/WHMapper.Tests/Services/Anoik/AnoikServicesTests.cs
+++ b/src/WHMapper.Tests/Services/Anoik/AnoikServicesTests.cs
@@ -38,7 +38,7 @@ namespace WHMapper.Tests.Services.Anoik
         {
             string? parameter = null;
             var service = new AnoikServices(logger, anoikDataSupplier);
-            Assert.ThrowsAny<ArgumentNullException>(() => service.GetSystemId(parameter));
+            Assert.ThrowsAny<ArgumentNullException>(() => service.GetSystemId(parameter!));
         }
 
         [Theory]

--- a/src/WHMapper.Tests/Services/Db/DbIntegrationTest.cs
+++ b/src/WHMapper.Tests/Services/Db/DbIntegrationTest.cs
@@ -49,7 +49,6 @@ public class DbIntegrationTest
 
     public DbIntegrationTest()
     {
-        //Create DB Context
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json")
             .AddEnvironmentVariables()
@@ -88,7 +87,6 @@ public class DbIntegrationTest
     public async Task CRUD_WHMAP()
     {
         Assert.NotNull(_contextFactory);
-        //Create IWHMapRepository
         IWHMapRepository repo = new WHMapRepository(new NullLogger<WHMapRepository>(),_contextFactory);
 
 
@@ -96,17 +94,14 @@ public class DbIntegrationTest
         Assert.NotNull(resEmpty);
         Assert.Empty(resEmpty);
 
-        //ADD WHMAP
         var result1 = await repo.Create(new WHMap(FOOBAR));
         Assert.NotNull(result1);
         Assert.Equal(FOOBAR, result1?.Name);
 
-        //ADD WHMAP
         var result2 = await repo.Create(new WHMap(FOOBAR2));
         Assert.NotNull(result2);
         Assert.Equal(FOOBAR2, result2?.Name);
 
-        //GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
@@ -114,13 +109,11 @@ public class DbIntegrationTest
         var resultDuplicate = await repo.Create(new WHMap(FOOBAR));
         Assert.Null(resultDuplicate);
 
-        //GetALL
         var results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.NotEmpty(results);
 
 
-        //GetById
         var resultById1 = await repo.GetById(1);
         Assert.NotNull(resultById1);
         Assert.Equal(1, resultById1.Id);
@@ -135,7 +128,6 @@ public class DbIntegrationTest
         resByBadId = await repo.GetById(-10);
         Assert.Null(resByBadId);
 
-        //getByName
         var resByName = await repo.GetByNameAsync(FOOBAR);
         Assert.NotNull(resByName);
         Assert.Equal(FOOBAR, resByName?.Name);
@@ -145,7 +137,6 @@ public class DbIntegrationTest
         Assert.Null(resBadName);
         
 
-        //update
         resultById1.Name = FOOBAR_UPDATED;
         var resultUpdate1 = await repo.Update(resultById1.Id, resultById1);
         Assert.NotNull(resultUpdate1);
@@ -155,13 +146,12 @@ public class DbIntegrationTest
         var resultUpdateBad = await repo.Update(-10, resultById1);
         Assert.Null(resultUpdateBad);
 
-        //update dupkicate
+        //update duplicate
         resultById2.Name = FOOBAR_UPDATED;
         var resultUpdate2 = await repo.Update(resultById2.Id, resultById2);
         Assert.Null(resultUpdate2);
 
 
-        //Delete WHMAP
         Assert.NotNull(result1);
         var resultDelete1 = await repo.DeleteById(result1.Id);
         Assert.True(resultDelete1);
@@ -169,7 +159,6 @@ public class DbIntegrationTest
         var resBadDelete = await repo.DeleteById(-10);
         Assert.False(resBadDelete);
 
-        //delete all
         var resultDeleteAll = await repo.DeleteAll();
         Assert.True(resultDeleteAll);
 
@@ -182,16 +171,12 @@ public class DbIntegrationTest
     public async Task CRUD_WHSystem()
     {
         Assert.NotNull(_contextFactory);
-        //init MAP
-        //Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(),_contextFactory);
 
-        //ADD WHMAP
         var map = await repoMap.Create(new WHMap(FOOBAR));
         Assert.NotNull(map);
         Assert.Equal(FOOBAR, map?.Name);
 
-        //Create IWHSystemRepository
         IWHSystemRepository repo = new WHSystemRepository(new NullLogger<WHSystemRepository>(),_contextFactory);
 
 
@@ -200,7 +185,6 @@ public class DbIntegrationTest
         Assert.NotNull(results);
         Assert.Empty(results);
 
-        //ADD WHSystem1
         Assert.NotNull(map);
         var result1 = await repo.Create(new WHSystem(map.Id, FOOBAR_SYSTEM_ID, FOOBAR, 1));
         Assert.NotNull(result1);
@@ -208,14 +192,12 @@ public class DbIntegrationTest
         Assert.Equal(1, result1?.SecurityStatus);
         Assert.False(result1?.Locked);
 
-        //ADD WHSystem2
         var result2 = await repo.Create(new WHSystem(map.Id, FOOBAR_SYSTEM_ID2, FOOBAR2, 1));
         Assert.NotNull(result2);
         Assert.Equal(FOOBAR2, result2?.Name);
         Assert.Equal(1, result2?.SecurityStatus);
         Assert.False(result2?.Locked);
 
-        //GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
@@ -223,12 +205,10 @@ public class DbIntegrationTest
         var resultDuplicate = await repo.Create(new WHSystem(map.Id, FOOBAR_SYSTEM_ID2, FOOBAR2, 1));
         Assert.Null(resultDuplicate);
 
-        //GetALL
         results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.NotEmpty(results);
 
-        //GetById
         Assert.NotNull(result1);
         var resultById= await repo.GetById(result1.Id);
         Assert.NotNull(resultById);
@@ -240,7 +220,6 @@ public class DbIntegrationTest
         Assert.Null(resBadById);
 
 
-        //update
         result1.Name = FOOBAR_UPDATED;
         result1.SecurityStatus = 0.5F;
         result1.AlternateName = FOOBAR_SHORT_UPDATED;
@@ -257,13 +236,11 @@ public class DbIntegrationTest
         Assert.Null(resultUpdateDuplicate);
 
 
-        //GetByName
         var resByName = await repo.GetByName(FOOBAR_UPDATED);
         Assert.NotNull(resByName);
         Assert.Equal(FOOBAR_UPDATED, resByName?.Name);
         Assert.Equal(0.5F, resByName?.SecurityStatus);
 
-        //Delete WHSytem
         var resDel1 = await repo.DeleteById(result1.Id);
         Assert.True(resDel1);
 
@@ -273,7 +250,6 @@ public class DbIntegrationTest
         var resBadDel = await repo.DeleteById(-10);
         Assert.False(resBadDel);
 
-        //Delete WHMAP
         var mapDeleted= await repoMap.DeleteById(map.Id);
         Assert.True(mapDeleted);
     }
@@ -282,17 +258,13 @@ public class DbIntegrationTest
     public async Task CRUD_WHLink()
     {
         Assert.NotNull(_contextFactory);
-        //init MAP
-        //Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(),_contextFactory);
 
-        //ADD WHMAP
         var map = await repoMap.Create(new WHMap(FOOBAR));
         Assert.NotNull(map);
         Assert.Equal(FOOBAR, map?.Name);
 
 
-        //Create IWHSystemRepository
         IWHSystemRepository repoWH = new WHSystemRepository(new NullLogger<WHSystemRepository>(),_contextFactory);
         Assert.NotNull(map);
         var whSys1 = await repoWH.Create(new WHSystem(map.Id,FOOBAR_SYSTEM_ID, FOOBAR, 1));
@@ -310,7 +282,6 @@ public class DbIntegrationTest
         Assert.Equal(Convert.ToByte('A'), whSys2.NameExtension);
         Assert.False(whSys2.Locked);
 
-        //GetCountAsync
         var count = await repoWH.GetCountAsync();
         Assert.Equal(2, count);
 
@@ -323,7 +294,6 @@ public class DbIntegrationTest
         Assert.False(whSys3.Locked);
 
 
-        //Create IWHSystemLinkRepository
         IWHSystemLinkRepository repo = new WHSystemLinkRepository(new NullLogger<WHSystemLinkRepository>(),_contextFactory);
 
 
@@ -331,7 +301,6 @@ public class DbIntegrationTest
         Assert.NotNull(resultAllEmpty);
         Assert.Empty(resultAllEmpty);
 
-        //add whsystem link1
         var link1 = await repo.Create(new WHSystemLink(map.Id,whSys1.Id, whSys2.Id));
         Assert.NotNull(link1);
         Assert.Equal(whSys1.Id, link1.IdWHSystemFrom);
@@ -340,7 +309,6 @@ public class DbIntegrationTest
         Assert.Equal(SystemLinkMassStatus.Normal, link1.MassStatus);
         Assert.Equal(SystemLinkSize.Large, link1.Size);
 
-        //add whsystem link2
         var link2 = await repo.Create(new WHSystemLink(map.Id, whSys1.Id, whSys3.Id));
         Assert.NotNull(link2);
         Assert.Equal(whSys1.Id, link2.IdWHSystemFrom);
@@ -349,7 +317,6 @@ public class DbIntegrationTest
         Assert.Equal(SystemLinkMassStatus.Normal, link2.MassStatus);
         Assert.Equal(SystemLinkSize.Large, link2.Size);
 
-        //GetCountAsync
         var countLinks = await repo.GetCountAsync();
         Assert.Equal(2, countLinks);
 
@@ -369,7 +336,6 @@ public class DbIntegrationTest
         var linkBadById = await repo.GetById(-10);
         Assert.Null(linkBadById);
 
-        //update link1
         link1.EndOfLifeStatus = SystemLinkEolStatus.EOL4h;
         link1.MassStatus = SystemLinkMassStatus.Verge;
         var linkUpdate1 = await repo.Update(link1.Id, link1);
@@ -380,12 +346,11 @@ public class DbIntegrationTest
         Assert.Equal(SystemLinkMassStatus.Verge, linkUpdate1.MassStatus);
         Assert.Equal(SystemLinkSize.Large, linkUpdate1.Size);
 
-        //update dupkicate
+        //update duplicate
         link2.IdWHSystemTo = linkUpdate1.IdWHSystemTo;
         var linkUpdateDuplicate = await repo.Update(link2.Id, link2);
         Assert.Null(linkUpdateDuplicate);
 
-        //Delete link
         var linkDel1 = await repo.DeleteById(link1.Id);
         Assert.True(linkDel1);
         var linkDel2 = await repo.DeleteById(link2.Id);
@@ -395,7 +360,6 @@ public class DbIntegrationTest
         Assert.False(linkBadDel);
 
 
-        //Delete WHMAP
         var mapDeleted = await repoMap.DeleteById(map.Id);
         Assert.True(mapDeleted);
 
@@ -407,17 +371,13 @@ public class DbIntegrationTest
     public async Task CRUD_WHSignature()
     {
         Assert.NotNull(_contextFactory);
-        //init MAP
-        //Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(),_contextFactory);
 
-        //ADD WHMAP
         var map = await repoMap.Create(new WHMap(FOOBAR));
         Assert.NotNull(map);
         Assert.Equal(FOOBAR, map?.Name);
 
 
-        //Create IWHMapRepository
         IWHSystemRepository repoWH = new WHSystemRepository(new NullLogger<WHSystemRepository>(),_contextFactory);
         Assert.NotNull(map);
         var whSys1 = await repoWH.Create(new WHSystem(map.Id, FOOBAR_SYSTEM_ID, FOOBAR, 1));
@@ -428,7 +388,6 @@ public class DbIntegrationTest
         Assert.False(whSys1.Locked);
 
 
-        //Create IWHMapRepository
         IWHSignatureRepository repo = new WHSignatureRepository(new NullLogger<WHSignatureRepository>(),_contextFactory);
 
         //get all empty
@@ -436,7 +395,6 @@ public class DbIntegrationTest
         Assert.NotNull(results);
         Assert.Empty(results);
 
-        //ADD WHSignature
         var result1 = await repo.Create(new WHSignature(whSys1.Id,FOOBAR));
         Assert.NotNull(result1);
         Assert.Equal(whSys1.Id, result1.WHId);
@@ -449,20 +407,17 @@ public class DbIntegrationTest
         Assert.Equal(FOOBAR2, result2?.Name);
         Assert.Equal(WHSignatureGroup.Unknow, result2?.Group);
 
-        //GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
         var resDuplicate = await repo.Create(new WHSignature(whSys1.Id, FOOBAR2));
         Assert.Null(resDuplicate);
 
-        //GetALL
         results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.NotEmpty(results);
 
 
-        //GetById
         var resById1 = await repo.GetById(1);
         Assert.NotNull(resById1);
         Assert.Equal(FOOBAR, resById1?.Name);
@@ -476,7 +431,6 @@ public class DbIntegrationTest
         var resBadbyId = await repo.GetById(-10);
         Assert.Null(resBadbyId);
 
-        //GetByWHId
         var resByWHId = await repo.GetByWHId(whSys1.Id);
         Assert.NotNull(resByWHId);
         Assert.NotEmpty(resByWHId);
@@ -485,7 +439,6 @@ public class DbIntegrationTest
         Assert.NotNull(resBadByWHId);
         Assert.Empty(resBadByWHId);
 
-        //GetByName
         var resByName1 = await repo.GetByName(FOOBAR);
         Assert.NotNull(resByName1);
         Assert.Equal(FOOBAR, resByName1.Name);
@@ -514,7 +467,6 @@ public class DbIntegrationTest
         Assert.NotNull(resultsUpdates);
         Assert.Contains(resultsUpdates, x => x?.UpdatedBy == FOOBAR);
 
-        //delete
         var resDel1 = await repo.DeleteById(resById1.Id);
         Assert.True(resDel1);
 
@@ -540,14 +492,12 @@ public class DbIntegrationTest
        Assert.NotNull(resultWHSigs);
        Assert.Equal(2, resultWHSigs.Count());
 
-        //delete
         deleteStatus = await repo.DeleteByWHId(whSys1.Id);//test good system but empty sig
         Assert.True(deleteStatus);
 
         deleteStatus = await repo.DeleteByWHId(-10);//test good system but empty sig
         Assert.False(deleteStatus);
 
-        //Delete WHMAP
         var mapDeleted = await repoMap.DeleteById(map.Id);
         Assert.True(mapDeleted);
 
@@ -557,16 +507,12 @@ public class DbIntegrationTest
     public async Task CRUD_WHNote()
     {
         Assert.NotNull(_contextFactory);
-        //init MAP
-        //Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(),_contextFactory);
 
-        //ADD WHMAP
         var map = await repoMap.Create(new WHMap(FOOBAR));
         Assert.NotNull(map);
         Assert.Equal(FOOBAR, map?.Name);
 
-        //Create AccessRepo
         IWHNoteRepository repo = new WHNoteRepository(new NullLogger<WHNoteRepository>(), _contextFactory);
 
         //get ALL empty
@@ -574,7 +520,6 @@ public class DbIntegrationTest
         Assert.NotNull(results);
         Assert.Empty(results);
 
-        //ADD Note1
         Assert.NotNull(map);
         var result1 = await repo.Create(new WHNote(map.Id,FOOBAR_SYSTEM_ID,FOOBAR));
         Assert.NotNull(result1);
@@ -582,14 +527,12 @@ public class DbIntegrationTest
         Assert.Equal(FOOBAR, result1.Comment);
         Assert.Equal(WHSystemStatus.Unknown, result1.SystemStatus);
 
-        //ADD Note2
         var result2 = await repo.Create(new WHNote(map.Id,FOOBAR_SYSTEM_ID2,WHSystemStatus.Hostile));
         Assert.NotNull(result2);
         Assert.Equal(FOOBAR_SYSTEM_ID2, result2.SoloarSystemId);
         Assert.Equal(string.Empty, result2.Comment);
         Assert.Equal(WHSystemStatus.Hostile, result2.SystemStatus);
         
-        //GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
@@ -597,13 +540,11 @@ public class DbIntegrationTest
         var resultDuplicate = await repo.Create(new WHNote(map.Id,FOOBAR_SYSTEM_ID2, FOOBAR));
         Assert.Null(resultDuplicate);
 
-        //GetALL
         results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.NotEmpty(results);
 
 
-        //GetbyID
         var resultById = await repo.GetById(1);
         Assert.NotNull(resultById);
         Assert.Equal(FOOBAR_SYSTEM_ID, resultById.SoloarSystemId);
@@ -612,7 +553,6 @@ public class DbIntegrationTest
         var resultBadById = await repo.GetById(-10);
         Assert.Null(resultBadById);
 
-        //Get
         var resultBySolarSystemId = await repo.Get(map.Id,FOOBAR_SYSTEM_ID);
         Assert.NotNull(resultBySolarSystemId);
         Assert.Equal(FOOBAR_SYSTEM_ID, resultBySolarSystemId.SoloarSystemId);
@@ -621,7 +561,6 @@ public class DbIntegrationTest
         var resultBadBySolarSystemId = await repo.Get(map.Id,-10);
         Assert.Null(resultBadBySolarSystemId);
 
-        //update
         result1.Comment = FOOBAR_SHORT_UPDATED;
         var resultUpdate1 = await repo.Update(result1.Id, result1);
         Assert.NotNull(resultUpdate1);
@@ -632,7 +571,6 @@ public class DbIntegrationTest
         var resultUpdate2 = await repo.Update(result2.Id, result2);
         Assert.Null(resultUpdate2);
 
-        //Delete
         var resultdel1 = await repo.DeleteById(result1.Id);
         Assert.True(resultdel1);
 
@@ -660,14 +598,11 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        // Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(), _contextFactory);
 
-        // Add WHMAP
         var map = await repoMap.Create(new WHMap(FOOBAR));
         Assert.NotNull(map);
 
-        // Create WHMapAccessRepository
         IWHMapAccessRepository repo = new WHMapAccessRepository(new NullLogger<WHMapAccessRepository>(), _contextFactory);
 
         // GetAll should be empty
@@ -675,7 +610,6 @@ public class DbIntegrationTest
         Assert.NotNull(results);
         Assert.Empty(results);
 
-        // Add access
         var access1 = await repo.Create(new WHMapAccess(map.Id, EVE_CHARACTERE_ID, EVE_CHARACTERE_NAME, WHAccessEntity.Character));
         Assert.NotNull(access1);
         Assert.Equal(map.Id, access1.WHMapId);
@@ -687,7 +621,6 @@ public class DbIntegrationTest
         var access2 = await repo.Create(new WHMapAccess(map.Id, EVE_CHARACTERE_ID2, EVE_CHARACTERE_NAME2, WHAccessEntity.Character));
         Assert.NotNull(access2);
 
-        // GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
@@ -695,12 +628,10 @@ public class DbIntegrationTest
         var duplicate = await repo.Create(new WHMapAccess(map.Id, EVE_CHARACTERE_ID, EVE_CHARACTERE_NAME, WHAccessEntity.Character));
         Assert.Null(duplicate);
 
-        // GetAll
         results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.NotEmpty(results);
 
-        // GetById
         var byId = await repo.GetById(access1.Id);
         Assert.NotNull(byId);
         Assert.Equal(EVE_CHARACTERE_ID, byId.EveEntityId);
@@ -708,7 +639,6 @@ public class DbIntegrationTest
         var badById = await repo.GetById(-10);
         Assert.Null(badById);
 
-        // Update
         access1.EveEntityName = "UPDATED";
         var updated = await repo.Update(access1.Id, access1);
         Assert.NotNull(updated);
@@ -719,7 +649,6 @@ public class DbIntegrationTest
         var updateDuplicate = await repo.Update(access2.Id, access2);
         Assert.Null(updateDuplicate);
 
-        // Delete
         var del1 = await repo.DeleteById(access1.Id);
         Assert.True(del1);
 
@@ -754,7 +683,6 @@ public class DbIntegrationTest
         ));
         Assert.NotNull(instance);
 
-        // Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(), _contextFactory);
 
         // Add WHMAP linked to instance
@@ -764,7 +692,6 @@ public class DbIntegrationTest
         var map2 = await repoMap.Create(new WHMap(FOOBAR2) { WHInstanceId = instance.Id });
         Assert.NotNull(map2);
 
-        // Create WHMapAccessRepository
         IWHMapAccessRepository repo = new WHMapAccessRepository(new NullLogger<WHMapAccessRepository>(), _contextFactory);
 
         // Test GetMapAccessesAsync - empty
@@ -867,7 +794,6 @@ public class DbIntegrationTest
         cleared = await repo.ClearMapAccessesAsync(map2.Id);
         Assert.True(cleared);
 
-        // Cleanup
         await repoMap.DeleteById(map.Id);
         await repoMap.DeleteById(map2.Id);
         await repoInstance.DeleteById(instance.Id);
@@ -878,7 +804,6 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        // Create repository
         IWHInstanceRepository repo = new WHInstanceRepository(new NullLogger<WHInstanceRepository>(), _contextFactory);
 
         // GetAll should be empty
@@ -916,7 +841,6 @@ public class DbIntegrationTest
         ));
         Assert.NotNull(instance2);
 
-        // GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
@@ -932,12 +856,10 @@ public class DbIntegrationTest
         ));
         Assert.Null(duplicate);
 
-        // GetAll
         results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.NotEmpty(results);
 
-        // GetById
         var byId = await repo.GetById(instance1.Id);
         Assert.NotNull(byId);
         Assert.Equal("Instance1", byId.Name);
@@ -945,7 +867,6 @@ public class DbIntegrationTest
         var badById = await repo.GetById(-10);
         Assert.Null(badById);
 
-        // Update
         instance1.Description = "UPDATED";
         var updated = await repo.Update(instance1.Id, instance1);
         Assert.NotNull(updated);
@@ -957,15 +878,12 @@ public class DbIntegrationTest
         var updateDuplicate = await repo.Update(instance2.Id, instance2);
         Assert.Null(updateDuplicate);
 
-        // Null update
         var nullUpdate = await repo.Update(-10, null!);
         Assert.Null(nullUpdate);
 
-        // Bad id update
         var badIdUpdate = await repo.Update(-10, instance1);
         Assert.Null(badIdUpdate);
 
-        // Delete
         var del1 = await repo.DeleteById(instance1.Id);
         Assert.True(del1);
 
@@ -989,10 +907,8 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        // Create repository
         IWHInstanceRepository repo = new WHInstanceRepository(new NullLogger<WHInstanceRepository>(), _contextFactory);
 
-        // Create instance
         var instance = await repo.Create(new WHInstance(
             "AdvancedTestInstance",
             EVE_CHARACTERE_ID,
@@ -1146,7 +1062,6 @@ public class DbIntegrationTest
         Assert.NotNull(accessibleInstances);
         Assert.DoesNotContain(accessibleInstances, i => i.Id == instance.Id);
 
-        // Cleanup
         await repoMap.DeleteById(map.Id);
         await repo.DeleteById(instance.Id);
     }
@@ -1156,10 +1071,8 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        // Create repository
         IWHInstanceRepository repo = new WHInstanceRepository(new NullLogger<WHInstanceRepository>(), _contextFactory);
 
-        // Create instance
         var instance = await repo.Create(new WHInstance(
             "EdgeCaseInstance",
             EVE_CHARACTERE_ID + 100,
@@ -1201,7 +1114,6 @@ public class DbIntegrationTest
         var admin = await repo.AddInstanceAdminAsync(instance.Id, EVE_CHARACTERE_ID + 100, EVE_CHARACTERE_NAME, true);
         Assert.NotNull(admin);
 
-        // Cleanup
         await repo.DeleteById(instance.Id);
     }
 
@@ -1210,14 +1122,11 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        // Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(), _contextFactory);
 
-        // Add WHMAP
         var map = await repoMap.Create(new WHMap("EdgeCaseMap"));
         Assert.NotNull(map);
 
-        // Create WHMapAccessRepository
         IWHMapAccessRepository repo = new WHMapAccessRepository(new NullLogger<WHMapAccessRepository>(), _contextFactory);
 
         // Test GetMapAccessCountAsync on empty map
@@ -1232,7 +1141,6 @@ public class DbIntegrationTest
         var hasAccess = await repo.HasMapAccessAsync(map.Id, 999, null, null);
         Assert.True(hasAccess); // No restrictions means access granted
 
-        // Add access
         var access = await repo.AddMapAccessAsync(new WHMapAccess(map.Id, EVE_CHARACTERE_ID, EVE_CHARACTERE_NAME, WHAccessEntity.Character));
         Assert.NotNull(access);
 
@@ -1261,7 +1169,6 @@ public class DbIntegrationTest
         var badIdUpdate = await repo.Update(-10, access);
         Assert.Null(badIdUpdate);
 
-        // Cleanup
         await repo.DeleteById(access.Id);
         await repoMap.DeleteById(map.Id);
     }
@@ -1271,17 +1178,13 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        // Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(), _contextFactory);
 
-        // Add WHMAP
         var map = await repoMap.Create(new WHMap("RemoveAccessMap"));
         Assert.NotNull(map);
 
-        // Create WHMapAccessRepository
         IWHMapAccessRepository repo = new WHMapAccessRepository(new NullLogger<WHMapAccessRepository>(), _contextFactory);
 
-        // Add access
         var access = await repo.AddMapAccessAsync(new WHMapAccess(map.Id, EVE_CHARACTERE_ID, EVE_CHARACTERE_NAME, WHAccessEntity.Character));
         Assert.NotNull(access);
 
@@ -1294,7 +1197,6 @@ public class DbIntegrationTest
         Assert.NotNull(accesses);
         Assert.Empty(accesses);
 
-        // Cleanup
         await repoMap.DeleteById(map.Id);
     }
 
@@ -1303,10 +1205,8 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        // Create repository
         IWHInstanceRepository repo = new WHInstanceRepository(new NullLogger<WHInstanceRepository>(), _contextFactory);
 
-        // Create instance
         var instance = await repo.Create(new WHInstance(
             "DuplicateAdminInstance",
             EVE_CHARACTERE_ID + 200,
@@ -1326,7 +1226,6 @@ public class DbIntegrationTest
         var duplicateAdmin = await repo.AddInstanceAdminAsync(instance.Id, EVE_CHARACTERE_ID, EVE_CHARACTERE_NAME, false);
         Assert.Null(duplicateAdmin);
 
-        // Cleanup
         await repo.DeleteById(instance.Id);
     }
 
@@ -1335,10 +1234,8 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        // Create repository
         IWHInstanceRepository repo = new WHInstanceRepository(new NullLogger<WHInstanceRepository>(), _contextFactory);
 
-        // Create instance
         var instance = await repo.Create(new WHInstance(
             "DuplicateAccessInstance",
             EVE_CHARACTERE_ID + 300,
@@ -1350,7 +1247,6 @@ public class DbIntegrationTest
         ));
         Assert.NotNull(instance);
 
-        // Add access
         var access = await repo.AddInstanceAccessAsync(new WHInstanceAccess(instance.Id, EVE_CORPO_ID, EVE_CORPO_NAME, WHAccessEntity.Corporation));
         Assert.NotNull(access);
 
@@ -1358,7 +1254,6 @@ public class DbIntegrationTest
         var duplicateAccess = await repo.AddInstanceAccessAsync(new WHInstanceAccess(instance.Id, EVE_CORPO_ID, EVE_CORPO_NAME, WHAccessEntity.Corporation));
         Assert.Null(duplicateAccess);
 
-        // Cleanup
         await repo.DeleteById(instance.Id);
     }
 
@@ -1366,11 +1261,8 @@ public class DbIntegrationTest
     public async Task CRUD_WHRoute()
     {
         Assert.NotNull(_contextFactory);
-        //init MAP
-        //Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(),_contextFactory);
 
-        //ADD WHMAP
         var map = await repoMap.Create(new WHMap(FOOBAR));
         Assert.NotNull(map);
         Assert.Equal(FOOBAR, map?.Name);
@@ -1396,7 +1288,6 @@ public class DbIntegrationTest
         Assert.Equal(FOOBAR_SYSTEM_ID2, result2.SolarSystemId);
         Assert.Equal(EVE_CORPO_ID, result2.EveEntityId);
 
-        //GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
@@ -1404,12 +1295,10 @@ public class DbIntegrationTest
         var resultDuplicate = await repo.Create(new WHRoute(map.Id,FOOBAR_SYSTEM_ID2, EVE_CORPO_ID));
         Assert.Null(resultDuplicate);
 
-        //GetALL
         results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.NotEmpty(results);
 
-        //GetbyID
         var resultById = await repo.GetById(1);
         Assert.NotNull(resultById);
         Assert.Equal(FOOBAR_SYSTEM_ID, resultById.SolarSystemId);
@@ -1429,7 +1318,6 @@ public class DbIntegrationTest
         var resultUpdate2 = await repo.Update(result2.Id, result2);
         Assert.Null(resultUpdate2);
 
-        //Delete
         var resultdel1 = await repo.DeleteById(result1.Id);
         Assert.True(resultdel1);
 
@@ -1458,7 +1346,6 @@ public class DbIntegrationTest
         var resultUpdateBadId = await repo.Update(-10, result1);
         Assert.Null(resultUpdateBadId);
 
-        //Delete
         var resultdel = await repo.DeleteById(result.Id);
         Assert.True(resultdel);
 
@@ -1473,17 +1360,13 @@ public class DbIntegrationTest
     {
         Assert.NotNull(_contextFactory);
 
-        //init MAP
-        //Create IWHMapRepository
         IWHMapRepository repoMap = new WHMapRepository(new NullLogger<WHMapRepository>(),_contextFactory);
 
-        //ADD WHMAP
         var map = await repoMap.Create(new WHMap(FOOBAR));
         Assert.NotNull(map);
         Assert.Equal(FOOBAR, map?.Name);
 
 
-        //Init two system IWHSystemRepository
         IWHSystemRepository repoWH = new WHSystemRepository(new NullLogger<WHSystemRepository>(),_contextFactory);
         Assert.NotNull(map);
         var whSys1 = await repoWH.Create(new WHSystem(map.Id,FOOBAR_SYSTEM_ID, FOOBAR, 1));
@@ -1491,14 +1374,12 @@ public class DbIntegrationTest
         var whSys2 = await repoWH.Create(new WHSystem(map.Id, FOOBAR_SYSTEM_ID2, FOOBAR2, 'A', 1));
         Assert.NotNull(whSys2);
 
-        //Init link 
         IWHSystemLinkRepository repoLink = new WHSystemLinkRepository(new NullLogger<WHSystemLinkRepository>(),_contextFactory);
 
         //add whsystem link1
         var link1 = await repoLink.Create(new WHSystemLink(map.Id,whSys1.Id, whSys2.Id));
         Assert.NotNull(link1);
 
-        //Create JumlLogRepo
         IWHJumpLogRepository repo = new WHJumpLogRepository(new NullLogger<WHJumpLogRepository>(), _contextFactory);
 
         //ADD JumpLog lmanuel 
@@ -1517,17 +1398,14 @@ public class DbIntegrationTest
         Assert.Equal(1037556721774, result2.ShipItemId);
         Assert.Equal(300000000, result2.ShipMass);
 
-        //GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
-        //GetALL
         var results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.NotEmpty(results);
         Assert.Equal(2, results.Count());
 
-        //GetbyID
         var resultById = await repo.GetById(1);
         Assert.NotNull(resultById);
         Assert.Equal(EVE_CHARACTERE_ID, resultById.CharacterId);
@@ -1553,7 +1431,6 @@ public class DbIntegrationTest
         var resultUpdate2 = await repo.Update(result2.Id, result2);
         Assert.Null(resultUpdate2);
 
-        //Delete
         var resultdel1 = await repo.DeleteById(result1.Id);
         Assert.True(resultdel1);
 
@@ -1579,7 +1456,6 @@ public class DbIntegrationTest
         Assert.NotNull(resEmpty);
         Assert.Empty(resEmpty);
 
-        // Create
         var result1 = await repo.Create(new WHUserSetting(EVE_CHARACTERE_ID));
         Assert.NotNull(result1);
         Assert.Equal(EVE_CHARACTERE_ID, result1!.EveCharacterId);
@@ -1604,16 +1480,13 @@ public class DbIntegrationTest
         var resultDuplicate = await repo.Create(new WHUserSetting(EVE_CHARACTERE_ID));
         Assert.Null(resultDuplicate);
 
-        // GetCountAsync
         var count = await repo.GetCountAsync();
         Assert.Equal(2, count);
 
-        // GetAll
         var results = await repo.GetAll();
         Assert.NotNull(results);
         Assert.Equal(2, results!.Count());
 
-        // GetById
         var resultById1 = await repo.GetById(result1.Id);
         Assert.NotNull(resultById1);
         Assert.Equal(result1.Id, resultById1!.Id);
@@ -1621,7 +1494,6 @@ public class DbIntegrationTest
         var resultBadById = await repo.GetById(-10);
         Assert.Null(resultBadById);
 
-        // GetByCharacterId
         var resultByChar = await repo.GetByCharacterId(EVE_CHARACTERE_ID);
         Assert.NotNull(resultByChar);
         Assert.Equal(EVE_CHARACTERE_ID, resultByChar!.EveCharacterId);
@@ -1647,14 +1519,12 @@ public class DbIntegrationTest
         var resultNullUpdate = await repo.Update(result1.Id, null!);
         Assert.Null(resultNullUpdate);
 
-        // DeleteById
         var resultDel1 = await repo.DeleteById(result1.Id);
         Assert.True(resultDel1);
 
         var resultBadDel = await repo.DeleteById(-10);
         Assert.False(resultBadDel);
 
-        // DeleteByCharacterId
         var resultDelByChar = await repo.DeleteByCharacterId(EVE_CHARACTERE_ID2);
         Assert.True(resultDelByChar);
 

--- a/src/WHMapper.Tests/Services/EveApi/EveAPIServicesTest.cs
+++ b/src/WHMapper.Tests/Services/EveApi/EveAPIServicesTest.cs
@@ -47,7 +47,6 @@ public class EveAPIServicesTest
         // Act
         var services = new EveAPIServices(httpClient);
 
-        // Assert
         Assert.NotNull(services.LocationServices);
         Assert.NotNull(services.UniverseServices);
         Assert.NotNull(services.UserInterfaceServices);
@@ -69,7 +68,6 @@ public class EveAPIServicesTest
         // Act
         var services = new EveAPIServices(httpClient);
 
-        // Assert
         Assert.IsAssignableFrom<ILocationServices>(services.LocationServices);
         Assert.IsAssignableFrom<IUniverseServices>(services.UniverseServices);
         Assert.IsAssignableFrom<IUserInterfaceServices>(services.UserInterfaceServices);
@@ -100,10 +98,8 @@ public class EveAPIServicesTest
         var services = new EveAPIServices(httpClient);
         var userToken = CreateTestUserToken();
 
-        // Act
         await services.SetEveCharacterAuthenticatication(userToken);
 
-        // Assert
         Assert.NotNull(services.LocationServices);
         Assert.NotNull(services.SearchServices);
         Assert.NotNull(services.DogmaServices);
@@ -137,7 +133,6 @@ public class EveAPIServicesTest
         var originalAssetsServices = services.AssetsServices;
         var originalUserInterfaceServices = services.UserInterfaceServices;
 
-        // Act
         await services.SetEveCharacterAuthenticatication(userToken);
 
         // Assert - Authenticated services should be new instances
@@ -162,7 +157,6 @@ public class EveAPIServicesTest
         var originalCharacterServices = services.CharacterServices;
         var originalRouteServices = services.RouteServices;
 
-        // Act
         await services.SetEveCharacterAuthenticatication(userToken);
 
         // Assert - Non-authenticated services should remain the same instances
@@ -187,14 +181,12 @@ public class EveAPIServicesTest
             Expiry = DateTime.UtcNow.AddHours(2)
         };
 
-        // Act
         await services.SetEveCharacterAuthenticatication(userToken1);
         var servicesAfterFirstCall = services.LocationServices;
 
         await services.SetEveCharacterAuthenticatication(userToken2);
         var servicesAfterSecondCall = services.LocationServices;
 
-        // Assert
         Assert.NotSame(servicesAfterFirstCall, servicesAfterSecondCall);
     }
 
@@ -229,7 +221,6 @@ public class EveAPIServicesTest
         var services = new EveAPIServices(httpClient);
         var userToken = CreateTestUserToken();
 
-        // Act
         await services.SetEveCharacterAuthenticatication(userToken);
 
         // Assert - Services should still implement their respective interfaces
@@ -248,10 +239,8 @@ public class EveAPIServicesTest
         var services = new EveAPIServices(httpClient);
         var userToken = CreateTestUserToken();
 
-        // Act
         var task = services.SetEveCharacterAuthenticatication(userToken);
 
-        // Assert
         Assert.True(task.IsCompleted);
         Assert.Equal(Task.CompletedTask, task);
     }

--- a/src/WHMapper.Tests/Services/EveApi/EveApiServiceBaseTest.cs
+++ b/src/WHMapper.Tests/Services/EveApi/EveApiServiceBaseTest.cs
@@ -61,7 +61,6 @@ public class EveApiServiceBaseTest
         // Act
         var result = await service.Execute<TestResponse>(RequestSecurity.Public, RequestMethod.Get, "/test");
 
-        // Assert
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Data);
         Assert.Equal(123, result.Data.Id);
@@ -82,7 +81,6 @@ public class EveApiServiceBaseTest
         // Act
         var result = await service.Execute<TestResponse>(RequestSecurity.Public, RequestMethod.Get, "/test");
 
-        // Assert
         Assert.True(result.IsSuccess);
         Assert.Null(result.Data);
     }
@@ -102,7 +100,6 @@ public class EveApiServiceBaseTest
         // Act
         var result = await service.Execute<TestResponse>(RequestSecurity.Public, RequestMethod.Get, "/test");
 
-        // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains("Failed to deserialize response", result.ErrorMessage);
         Assert.Equal(200, result.StatusCode);
@@ -124,7 +121,6 @@ public class EveApiServiceBaseTest
         // Act
         var result = await service.Execute<TestResponse>(RequestSecurity.Public, RequestMethod.Get, "/test");
 
-        // Assert
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Data);
         Assert.Equal(0, result.Data.Id);
@@ -147,7 +143,6 @@ public class EveApiServiceBaseTest
         // Act
         var result = await service.Execute<TestResponse>(RequestSecurity.Public, RequestMethod.Post, "/test");
 
-        // Assert
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Data);
         Assert.Equal(456, result.Data.Id);
@@ -170,7 +165,6 @@ public class EveApiServiceBaseTest
         // Act
         var result = await service.Execute<TestResponse>(RequestSecurity.Public, RequestMethod.Put, "/test");
 
-        // Assert
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Data);
         Assert.Equal(789, result.Data.Id);
@@ -192,7 +186,6 @@ public class EveApiServiceBaseTest
         // Act
         var result = await service.Execute<TestResponse>(RequestSecurity.Public, RequestMethod.Get, "/test");
 
-        // Assert
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Data);
         Assert.Equal(999, result.Data.Id);
@@ -214,7 +207,6 @@ public class EveApiServiceBaseTest
         // Act
         var result = await service.Execute<TestResponse[]>(RequestSecurity.Public, RequestMethod.Get, "/test");
 
-        // Assert
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Data);
         Assert.Equal(2, result.Data.Length);

--- a/src/WHMapper.Tests/Services/EveApi/LocationServicesTest.cs
+++ b/src/WHMapper.Tests/Services/EveApi/LocationServicesTest.cs
@@ -53,7 +53,6 @@ namespace WHMapper.Tests.Services.EveAPI.Locations
             // Act
             var result = await locationServices.GetLocation();
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(expectedLocation.SolarSystemId, result?.Data?.SolarSystemId);
         }
@@ -122,7 +121,6 @@ namespace WHMapper.Tests.Services.EveAPI.Locations
             // Act
             var result = await locationServices.GetCurrentShip();
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(expectedShip.ShipTypeId, result?.Data?.ShipTypeId);
             Assert.Equal(expectedShip.ShipName, result?.Data?.ShipName);
@@ -137,7 +135,6 @@ namespace WHMapper.Tests.Services.EveAPI.Locations
             // Act
             var result = await locationServices.GetCurrentShip();
 
-            // Assert
             Assert.NotNull(result);
             Assert.False(result.IsSuccess);
             Assert.Equal(result.StatusCode,  (int)HttpStatusCode.Unauthorized);
@@ -164,7 +161,6 @@ namespace WHMapper.Tests.Services.EveAPI.Locations
             // Act
             var result = await locationServices.GetCurrentShip();
 
-            // Assert
             Assert.NotNull(result);
             Assert.False(result.IsSuccess);
             Assert.Equal(result.StatusCode,  (int)HttpStatusCode.BadRequest);

--- a/src/WHMapper.Tests/Services/EveMapper/EveMapperAccessHelperTests.cs
+++ b/src/WHMapper.Tests/Services/EveMapper/EveMapperAccessHelperTests.cs
@@ -72,7 +72,6 @@ namespace WHMapper.Tests.Services.EveMapper
         [Theory, AutoMoqData]
         public async Task IfCharacterNotFound_WhenGettingAccess_ReturnsFalse(
             [Frozen] Mock<ICharacterServices> characterServices,
-            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
             EveMapperAccessHelper sut)
         {
             characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))

--- a/src/WHMapper.Tests/Services/EveMapper/EveMapperAccessHelperTests.cs
+++ b/src/WHMapper.Tests/Services/EveMapper/EveMapperAccessHelperTests.cs
@@ -6,6 +6,7 @@ using WHMapper.Models.Db;
 using WHMapper.Models.DTO;
 using WHMapper.Models.DTO.EveAPI.Character;
 using WHMapper.Repositories.WHInstances;
+using WHMapper.Repositories.WHMapAccesses;
 using WHMapper.Repositories.WHMaps;
 using WHMapper.Services.EveAPI.Characters;
 using WHMapper.Services.EveMapper;
@@ -130,6 +131,7 @@ namespace WHMapper.Tests.Services.EveMapper
             [Frozen] Mock<ICharacterServices> characterServices,
             [Frozen] Mock<IWHMapRepository> mapRepository,
             [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            [Frozen] Mock<IWHMapAccessRepository> mapAccessRepository,
             EveMapperAccessHelper sut)
         {
             map.WHInstanceId = 1;
@@ -143,7 +145,75 @@ namespace WHMapper.Tests.Services.EveMapper
             instanceRepository.Setup(x => x.HasInstanceAccessAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
                 .ReturnsAsync(true);
 
+            mapAccessRepository.Setup(x => x.HasMapAccessAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(true);
+
             Assert.True(await sut.IsEveMapperMapAccessAuthorized(1, map.Id));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfCharacterNotFound_WhenGettingMapAccess_ReturnsFalse(
+            WHMap map,
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHMapRepository> mapRepository,
+            EveMapperAccessHelper sut)
+        {
+            map.WHInstanceId = 1;
+            mapRepository.Setup(x => x.GetById(It.IsAny<int>()))
+                .ReturnsAsync(map);
+
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Failure("Character not found"));
+
+            Assert.False(await sut.IsEveMapperMapAccessAuthorized(1, map.Id));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfUserHasNoInstanceAccess_WhenGettingMapAccess_ReturnsFalse(
+            WHMap map,
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHMapRepository> mapRepository,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            map.WHInstanceId = 1;
+            mapRepository.Setup(x => x.GetById(It.IsAny<int>()))
+                .ReturnsAsync(map);
+
+            var character = new Character() { CorporationId = 100, AllianceId = 200 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.HasInstanceAccessAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(false);
+
+            Assert.False(await sut.IsEveMapperMapAccessAuthorized(1, map.Id));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfUserHasInstanceAccessButNoMapAccess_WhenGettingMapAccess_ReturnsFalse(
+            WHMap map,
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHMapRepository> mapRepository,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            [Frozen] Mock<IWHMapAccessRepository> mapAccessRepository,
+            EveMapperAccessHelper sut)
+        {
+            map.WHInstanceId = 1;
+            mapRepository.Setup(x => x.GetById(It.IsAny<int>()))
+                .ReturnsAsync(map);
+
+            var character = new Character() { CorporationId = 100, AllianceId = 200 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.HasInstanceAccessAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(true);
+
+            mapAccessRepository.Setup(x => x.HasMapAccessAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(false);
+
+            Assert.False(await sut.IsEveMapperMapAccessAuthorized(1, map.Id));
         }
 
         [Theory, AutoMoqData]
@@ -204,6 +274,236 @@ namespace WHMapper.Tests.Services.EveMapper
 
             var characterIds = new List<int> { 1, 2, 3 };
             Assert.False(await sut.IsEveMapperUserAccessAuthorizedForAny(characterIds));
+        }
+        #endregion
+
+        #region IsEveMapperInstanceAccessAuthorized()
+        [Theory, AutoMoqData]
+        public async Task IfCharacterNotFound_WhenGettingInstanceAccess_ReturnsFalse(
+            [Frozen] Mock<ICharacterServices> characterServices,
+            EveMapperAccessHelper sut)
+        {
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Failure("Character not found"));
+
+            Assert.False(await sut.IsEveMapperInstanceAccessAuthorized(1, 1));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfUserHasAccess_WhenGettingInstanceAccess_ReturnsTrue(
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            var character = new Character() { CorporationId = 100, AllianceId = 200 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.HasInstanceAccessAsync(1, 1, 100, 200))
+                .ReturnsAsync(true);
+
+            Assert.True(await sut.IsEveMapperInstanceAccessAuthorized(1, 1));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfUserHasNoCorpOrAllianceAndNoAccess_WhenGettingInstanceAccess_ReturnsFalse(
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            var character = new Character() { CorporationId = 0, AllianceId = 0 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.HasInstanceAccessAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(false);
+
+            Assert.False(await sut.IsEveMapperInstanceAccessAuthorized(1, 1));
+            instanceRepository.Verify(x => x.HasInstanceAccessAsync(1, 1, null, null), Times.Once);
+        }
+        #endregion
+
+        #region GetAccessibleInstanceIdsAsync()
+        [Theory, AutoMoqData]
+        public async Task IfCharacterNotFound_WhenGettingAccessibleInstanceIds_ReturnsEmpty(
+            [Frozen] Mock<ICharacterServices> characterServices,
+            EveMapperAccessHelper sut)
+        {
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Failure("Character not found"));
+
+            Assert.Empty(await sut.GetAccessibleInstanceIdsAsync(1));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfInstancesAccessible_WhenGettingAccessibleInstanceIds_ReturnsTheirIds(
+            WHInstance instance1,
+            WHInstance instance2,
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            var character = new Character() { CorporationId = 100, AllianceId = 200 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.GetAccessibleInstancesAsync(It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(new List<WHInstance> { instance1, instance2 });
+
+            var ids = await sut.GetAccessibleInstanceIdsAsync(1);
+
+            Assert.Equal(new[] { instance1.Id, instance2.Id }, ids);
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfRepositoryReturnsNull_WhenGettingAccessibleInstanceIds_ReturnsEmpty(
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            var character = new Character() { CorporationId = 100, AllianceId = 200 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.GetAccessibleInstancesAsync(It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync((IEnumerable<WHInstance>?)null);
+
+            Assert.Empty(await sut.GetAccessibleInstanceIdsAsync(1));
+        }
+        #endregion
+
+        #region IsInstanceAdminAuthorized()
+        [Theory]
+        [InlineAutoMoqData(true)]
+        [InlineAutoMoqData(false)]
+        public async Task WhenCheckingInstanceAdmin_ReturnsRepositoryResult(
+            bool isAdmin,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            instanceRepository.Setup(x => x.IsInstanceAdminAsync(2, 1))
+                .ReturnsAsync(isAdmin);
+
+            Assert.Equal(isAdmin, await sut.IsInstanceAdminAuthorized(1, 2));
+        }
+        #endregion
+
+        #region GetMapInstanceIdAsync()
+        [Theory, AutoMoqData]
+        public async Task IfMapDoesNotExist_WhenGettingMapInstanceId_ReturnsNull(
+            [Frozen] Mock<IWHMapRepository> mapRepository,
+            EveMapperAccessHelper sut)
+        {
+            mapRepository.Setup(x => x.GetById(It.IsAny<int>()))
+                .ReturnsAsync((WHMap?)null);
+
+            Assert.Null(await sut.GetMapInstanceIdAsync(1));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfMapExists_WhenGettingMapInstanceId_ReturnsItsInstanceId(
+            WHMap map,
+            [Frozen] Mock<IWHMapRepository> mapRepository,
+            EveMapperAccessHelper sut)
+        {
+            map.WHInstanceId = 42;
+            mapRepository.Setup(x => x.GetById(map.Id))
+                .ReturnsAsync(map);
+
+            Assert.Equal(42, await sut.GetMapInstanceIdAsync(map.Id));
+        }
+        #endregion
+
+        #region Corp/alliance id branches
+        [Theory, AutoMoqData]
+        public async Task IfRepositoryReturnsNull_WhenGettingAccess_ReturnsFalse(
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            var character = new Character() { CorporationId = 100, AllianceId = 200 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.GetAccessibleInstancesAsync(It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync((IEnumerable<WHInstance>?)null);
+
+            Assert.False(await sut.IsEveMapperUserAccessAuthorized(1));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfRepositoryReturnsNull_WhenGettingAdminState_ReturnsFalse(
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            instanceRepository.Setup(x => x.GetInstancesForAdminAsync(It.IsAny<int>()))
+                .ReturnsAsync((IEnumerable<WHInstance>?)null);
+
+            Assert.False(await sut.IsEveMapperAdminAccessAuthorized(1));
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfCharacterHasNoCorpOrAlliance_WhenGettingMapAccess_PassesNullIds(
+            WHMap map,
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHMapRepository> mapRepository,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            [Frozen] Mock<IWHMapAccessRepository> mapAccessRepository,
+            EveMapperAccessHelper sut)
+        {
+            map.WHInstanceId = 1;
+            mapRepository.Setup(x => x.GetById(It.IsAny<int>()))
+                .ReturnsAsync(map);
+
+            var character = new Character() { CorporationId = 0, AllianceId = 0 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.HasInstanceAccessAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(true);
+
+            mapAccessRepository.Setup(x => x.HasMapAccessAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(true);
+
+            Assert.True(await sut.IsEveMapperMapAccessAuthorized(1, map.Id));
+            instanceRepository.Verify(x => x.HasInstanceAccessAsync(1, 1, null, null), Times.Once);
+            mapAccessRepository.Verify(x => x.HasMapAccessAsync(map.Id, 1, null, null), Times.Once);
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfCharacterHasNoCorpOrAlliance_WhenGettingAccessibleInstanceIds_PassesNullIds(
+            WHInstance instance,
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            var character = new Character() { CorporationId = 0, AllianceId = 0 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.GetAccessibleInstancesAsync(It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(new List<WHInstance> { instance });
+
+            Assert.Equal(new[] { instance.Id }, await sut.GetAccessibleInstanceIdsAsync(1));
+            instanceRepository.Verify(x => x.GetAccessibleInstancesAsync(1, null, null), Times.Once);
+        }
+
+        [Theory, AutoMoqData]
+        public async Task IfCharacterHasNoCorpOrAlliance_WhenGettingAccess_PassesNullIds(
+            WHInstance instance,
+            [Frozen] Mock<ICharacterServices> characterServices,
+            [Frozen] Mock<IWHInstanceRepository> instanceRepository,
+            EveMapperAccessHelper sut)
+        {
+            var character = new Character() { CorporationId = 0, AllianceId = 0 };
+            characterServices.Setup(x => x.GetCharacter(It.IsAny<int>()))
+                .ReturnsAsync(Result<Character>.Success(character));
+
+            instanceRepository.Setup(x => x.GetAccessibleInstancesAsync(It.IsAny<int>(), It.IsAny<int?>(), It.IsAny<int?>()))
+                .ReturnsAsync(new List<WHInstance> { instance });
+
+            Assert.True(await sut.IsEveMapperUserAccessAuthorized(1));
+            instanceRepository.Verify(x => x.GetAccessibleInstancesAsync(1, null, null), Times.Once);
         }
         #endregion
     }

--- a/src/WHMapper.Tests/Services/EveMapper/EveMapperInstanceServiceTest.cs
+++ b/src/WHMapper.Tests/Services/EveMapper/EveMapperInstanceServiceTest.cs
@@ -72,7 +72,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.GetInstanceAsync(instanceId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(instanceId, result.Id);
             Assert.Equal("TestInstance", result.Name);
@@ -89,7 +88,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.GetInstanceAsync(instanceId);
 
-            // Assert
             Assert.Null(result);
             _instanceRepoMock.Verify(r => r.GetById(instanceId), Times.Once);
         }
@@ -102,10 +100,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var existingInstance = new WHInstance("Existing", ownerEntityId, "Owner", WHAccessEntity.Character, 200, "Creator") { Id = 1 };
             _instanceRepoMock.Setup(r => r.GetByOwnerAsync(ownerEntityId)).ReturnsAsync(existingInstance);
 
-            // Act
             var result = await _service.CreateInstanceAsync("New", null, ownerEntityId, "Owner", WHAccessEntity.Character, 200, "Creator");
 
-            // Assert
             Assert.Null(result);
             _instanceRepoMock.Verify(r => r.GetByOwnerAsync(ownerEntityId), Times.Once);
         }
@@ -121,10 +117,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.AddInstanceAdminAsync(instance.Id, 201, "Creator", true)).ReturnsAsync(new Mock<WHInstanceAdmin>().Object);
             _instanceRepoMock.Setup(r => r.AddInstanceAccessAsync(It.IsAny<WHInstanceAccess>())).ReturnsAsync(new WHInstanceAccess(instance.Id, ownerEntityId, "Owner", WHAccessEntity.Character));
 
-            // Act
             var result = await _service.CreateInstanceAsync("New", "desc", ownerEntityId, "Owner", WHAccessEntity.Character, 201, "Creator");
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(instance.Id, result.Id);
             _instanceRepoMock.Verify(r => r.GetByOwnerAsync(ownerEntityId), Times.Once);
@@ -144,10 +138,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.AddInstanceAdminAsync(instance.Id, 202, "Creator", true)).ReturnsAsync((WHInstanceAdmin?)null);
             _instanceRepoMock.Setup(r => r.DeleteById(instance.Id)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.CreateInstanceAsync("New", null, ownerEntityId, "Owner", WHAccessEntity.Character, 202, "Creator");
 
-            // Assert
             Assert.Null(result);
             _instanceRepoMock.Verify(r => r.DeleteById(instance.Id), Times.Once);
         }
@@ -161,7 +153,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var locked = await service.IsInstanceCreationLockedAsync();
 
-            // Assert
             Assert.False(locked);
             _instanceRepoMock.Verify(r => r.AnyAsync(), Times.Never);
         }
@@ -176,7 +167,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var locked = await service.IsInstanceCreationLockedAsync();
 
-            // Assert
             Assert.False(locked);
         }
 
@@ -190,7 +180,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var locked = await service.IsInstanceCreationLockedAsync();
 
-            // Assert
             Assert.True(locked);
         }
 
@@ -201,10 +190,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var service = BuildService(singleTenantMode: true);
             _instanceRepoMock.Setup(r => r.AnyAsync()).ReturnsAsync(true);
 
-            // Act
             var result = await service.CreateInstanceAsync("New", null, 999, "Owner", WHAccessEntity.Character, 200, "Creator");
 
-            // Assert
             Assert.Null(result);
             _instanceRepoMock.Verify(r => r.GetByOwnerAsync(It.IsAny<int>()), Times.Never);
             _instanceRepoMock.Verify(r => r.Create(It.IsAny<WHInstance>()), Times.Never);
@@ -220,7 +207,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var canRegister = await service.CanRegisterAsync(999);
 
-            // Assert
             Assert.False(canRegister);
             _instanceRepoMock.Verify(r => r.GetByOwnerAsync(It.IsAny<int>()), Times.Never);
         }
@@ -237,7 +223,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.UpdateInstanceAsync(instanceId, "Updated", "NewDesc");
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal("Updated", result.Name);
             Assert.Equal("NewDesc", result.Description);
@@ -254,7 +239,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.UpdateInstanceAsync(instanceId, "Name", "Desc");
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -266,10 +250,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 300;
             _instanceRepoMock.Setup(r => r.GetById(instanceId)).ReturnsAsync(new WHInstance("Name", 104, "Owner", WHAccessEntity.Character, 301, "Creator") { Id = instanceId });
 
-            // Act
             var result = await _service.DeleteInstanceAsync(instanceId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -283,10 +265,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.GetById(instanceId)).ReturnsAsync(instance);
             _instanceRepoMock.Setup(r => r.DeleteById(instanceId)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.DeleteInstanceAsync(instanceId, creatorCharacterId);
 
-            // Assert
             Assert.True(result);
             _instanceRepoMock.Verify(r => r.DeleteById(instanceId), Times.Once);
         }
@@ -299,10 +279,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 400;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.AddAdminAsync(instanceId, 401, "NewAdmin", requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -315,10 +293,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _instanceRepoMock.Setup(r => r.AddInstanceAdminAsync(instanceId, 501, "NewAdmin", false)).ReturnsAsync(new Mock<WHInstanceAdmin>().Object);
 
-            // Act
             var result = await _service.AddAdminAsync(instanceId, 501, "NewAdmin", requestingCharacterId);
 
-            // Assert
             Assert.NotNull(result);
             _instanceRepoMock.Verify(r => r.AddInstanceAdminAsync(instanceId, 501, "NewAdmin", false), Times.Once);
         }
@@ -331,10 +307,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 600;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.RemoveAdminAsync(instanceId, 601, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -347,10 +321,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _instanceRepoMock.Setup(r => r.RemoveInstanceAdminAsync(instanceId, 701)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.RemoveAdminAsync(instanceId, 701, requestingCharacterId);
 
-            // Assert
             Assert.True(result);
             _instanceRepoMock.Verify(r => r.RemoveInstanceAdminAsync(instanceId, 701), Times.Once);
         }
@@ -363,10 +335,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 800;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.AddAccessAsync(instanceId, 801, "Entity", WHAccessEntity.Corporation, requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -379,10 +349,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _instanceRepoMock.Setup(r => r.AddInstanceAccessAsync(It.IsAny<WHInstanceAccess>())).ReturnsAsync(new WHInstanceAccess(instanceId, 901, "Entity", WHAccessEntity.Corporation));
 
-            // Act
             var result = await _service.AddAccessAsync(instanceId, 901, "Entity", WHAccessEntity.Corporation, requestingCharacterId);
 
-            // Assert
             Assert.NotNull(result);
             _instanceRepoMock.Verify(r => r.AddInstanceAccessAsync(It.IsAny<WHInstanceAccess>()), Times.Once);
         }
@@ -395,10 +363,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 1000;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var (success, removed) = await _service.RemoveAccessAsync(instanceId, 1001, requestingCharacterId);
 
-            // Assert
             Assert.False(success);
             Assert.Empty(removed);
         }
@@ -412,10 +378,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _instanceRepoMock.Setup(r => r.GetInstanceAccessesAsync(instanceId)).ReturnsAsync(new List<WHInstanceAccess>());
 
-            // Act
             var (success, removed) = await _service.RemoveAccessAsync(instanceId, 1101, requestingCharacterId);
 
-            // Assert
             Assert.False(success);
             Assert.Empty(removed);
         }
@@ -435,10 +399,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _mapAccessRepoMock.Setup(r => r.RemoveMapAccessesByEntityAsync(instanceId, access.EveEntityId, access.EveEntity)).ReturnsAsync(removedMapAccesses);
             _instanceRepoMock.Setup(r => r.RemoveInstanceAccessAsync(instanceId, accessId)).ReturnsAsync(true);
 
-            // Act
             var (success, removed) = await _service.RemoveAccessAsync(instanceId, accessId, requestingCharacterId);
 
-            // Assert
             Assert.True(success);
             Assert.Equal(removedMapAccesses, removed);
         }
@@ -453,7 +415,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.CanRegisterAsync(ownerEntityId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -467,7 +428,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.CanRegisterAsync(ownerEntityId);
 
-            // Assert
             Assert.True(result);
         }
 
@@ -480,10 +440,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var instance = new WHInstance("Name", 1502, "Owner", WHAccessEntity.Character, characterId, "Creator") { Id = instanceId };
             _instanceRepoMock.Setup(r => r.GetById(instanceId)).ReturnsAsync(instance);
 
-            // Act
             var result = await _service.IsOwnerAsync(instanceId, characterId);
 
-            // Assert
             Assert.True(result);
         }
 
@@ -496,10 +454,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var instance = new WHInstance("Name", 1602, "Owner", WHAccessEntity.Character, 1603, "Creator") { Id = instanceId };
             _instanceRepoMock.Setup(r => r.GetById(instanceId)).ReturnsAsync(instance);
 
-            // Act
             var result = await _service.IsOwnerAsync(instanceId, characterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -511,10 +467,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var characterId = 1701;
             _instanceRepoMock.Setup(r => r.GetById(instanceId)).ReturnsAsync((WHInstance?)null);
 
-            // Act
             var result = await _service.IsOwnerAsync(instanceId, characterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -529,7 +483,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.GetInstanceByOwnerAsync(ownerEntityId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(ownerEntityId, result.OwnerEveEntityId);
         }
@@ -544,7 +497,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.GetInstanceByOwnerAsync(ownerEntityId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -560,10 +512,8 @@ namespace WHMapper.Tests.Services.EveMapper
             };
             _instanceRepoMock.Setup(r => r.GetInstancesForAdminAsync(characterId)).ReturnsAsync(instances);
 
-            // Act
             var result = await _service.GetAdministeredInstancesAsync(characterId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(2, result.Count());
         }
@@ -581,10 +531,8 @@ namespace WHMapper.Tests.Services.EveMapper
             };
             _instanceRepoMock.Setup(r => r.GetAccessibleInstancesAsync(characterId, corpId, allianceId)).ReturnsAsync(instances);
 
-            // Act
             var result = await _service.GetAccessibleInstancesAsync(characterId, corpId, allianceId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Single(result);
         }
@@ -604,7 +552,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.GetAdminsAsync(instanceId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(2, result.Count());
         }
@@ -617,10 +564,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var characterId = 2301;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, characterId)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.IsAdminAsync(instanceId, characterId);
 
-            // Assert
             Assert.True(result);
         }
 
@@ -632,10 +577,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var characterId = 2401;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, characterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.IsAdminAsync(instanceId, characterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -654,7 +597,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.GetAccessesAsync(instanceId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(2, result.Count());
         }
@@ -669,10 +611,8 @@ namespace WHMapper.Tests.Services.EveMapper
             int? allianceId = 2603;
             _instanceRepoMock.Setup(r => r.HasInstanceAccessAsync(instanceId, characterId, corpId, allianceId)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.HasAccessAsync(instanceId, characterId, corpId, allianceId);
 
-            // Assert
             Assert.True(result);
         }
 
@@ -686,10 +626,8 @@ namespace WHMapper.Tests.Services.EveMapper
             int? allianceId = 2703;
             _instanceRepoMock.Setup(r => r.HasInstanceAccessAsync(instanceId, characterId, corpId, allianceId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.HasAccessAsync(instanceId, characterId, corpId, allianceId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -701,10 +639,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 2801;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.CreateMapAsync(instanceId, "MapName", requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -718,10 +654,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.Create(It.IsAny<WHMap>())).ReturnsAsync(map);
 
-            // Act
             var result = await _service.CreateMapAsync(instanceId, "NewMap", requestingCharacterId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal("NewMap", result.Name);
             _mapRepoMock.Verify(r => r.Create(It.IsAny<WHMap>()), Times.Once);
@@ -736,10 +670,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 3002;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.DeleteMapAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -753,10 +685,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync((WHMap?)null);
 
-            // Act
             var result = await _service.DeleteMapAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -771,10 +701,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
 
-            // Act
             var result = await _service.DeleteMapAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -790,10 +718,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
             _mapRepoMock.Setup(r => r.DeleteById(mapId)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.DeleteMapAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.True(result);
             _mapRepoMock.Verify(r => r.DeleteById(mapId), Times.Once);
         }
@@ -813,7 +739,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.GetMapsAsync(instanceId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(2, result.Count());
         }
@@ -827,10 +752,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 3502;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.GetMapAccessesAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -844,10 +767,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync((WHMap?)null);
 
-            // Act
             var result = await _service.GetMapAccessesAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -862,10 +783,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
 
-            // Act
             var result = await _service.GetMapAccessesAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -886,10 +805,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
             _mapAccessRepoMock.Setup(r => r.GetMapAccessesAsync(mapId)).ReturnsAsync(accesses);
 
-            // Act
             var result = await _service.GetMapAccessesAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(2, result.Count());
         }
@@ -903,10 +820,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 3902;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.AddMapAccessAsync(instanceId, mapId, 3903, "Entity", WHAccessEntity.Character, requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -920,10 +835,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync((WHMap?)null);
 
-            // Act
             var result = await _service.AddMapAccessAsync(instanceId, mapId, 4003, "Entity", WHAccessEntity.Character, requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -938,10 +851,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
 
-            // Act
             var result = await _service.AddMapAccessAsync(instanceId, mapId, 4103, "Entity", WHAccessEntity.Character, requestingCharacterId);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -958,10 +869,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
             _mapAccessRepoMock.Setup(r => r.AddMapAccessAsync(It.IsAny<WHMapAccess>())).ReturnsAsync(access);
 
-            // Act
             var result = await _service.AddMapAccessAsync(instanceId, mapId, 4203, "Entity", WHAccessEntity.Character, requestingCharacterId);
 
-            // Assert
             Assert.NotNull(result);
             _mapAccessRepoMock.Verify(r => r.AddMapAccessAsync(It.IsAny<WHMapAccess>()), Times.Once);
         }
@@ -976,10 +885,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 4303;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.RemoveMapAccessAsync(instanceId, mapId, accessId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -994,10 +901,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync((WHMap?)null);
 
-            // Act
             var result = await _service.RemoveMapAccessAsync(instanceId, mapId, accessId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -1013,10 +918,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
 
-            // Act
             var result = await _service.RemoveMapAccessAsync(instanceId, mapId, accessId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -1033,10 +936,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
             _mapAccessRepoMock.Setup(r => r.RemoveMapAccessAsync(mapId, accessId)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.RemoveMapAccessAsync(instanceId, mapId, accessId, requestingCharacterId);
 
-            // Assert
             Assert.True(result);
             _mapAccessRepoMock.Verify(r => r.RemoveMapAccessAsync(mapId, accessId), Times.Once);
         }
@@ -1050,10 +951,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var requestingCharacterId = 4702;
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.ClearMapAccessesAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -1067,10 +966,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync((WHMap?)null);
 
-            // Act
             var result = await _service.ClearMapAccessesAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -1085,10 +982,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, requestingCharacterId)).ReturnsAsync(true);
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
 
-            // Act
             var result = await _service.ClearMapAccessesAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -1104,10 +999,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _mapRepoMock.Setup(r => r.GetById(mapId)).ReturnsAsync(map);
             _mapAccessRepoMock.Setup(r => r.ClearMapAccessesAsync(mapId)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.ClearMapAccessesAsync(instanceId, mapId, requestingCharacterId);
 
-            // Assert
             Assert.True(result);
             _mapAccessRepoMock.Verify(r => r.ClearMapAccessesAsync(mapId), Times.Once);
         }
@@ -1123,10 +1016,8 @@ namespace WHMapper.Tests.Services.EveMapper
             int? allianceId = 5104;
             _instanceRepoMock.Setup(r => r.HasInstanceAccessAsync(instanceId, characterId, corpId, allianceId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.HasMapAccessAsync(instanceId, mapId, characterId, corpId, allianceId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -1142,10 +1033,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.HasInstanceAccessAsync(instanceId, characterId, corpId, allianceId)).ReturnsAsync(true);
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, characterId)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.HasMapAccessAsync(instanceId, mapId, characterId, corpId, allianceId);
 
-            // Assert
             Assert.True(result);
         }
 
@@ -1162,10 +1051,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, characterId)).ReturnsAsync(false);
             _mapAccessRepoMock.Setup(r => r.HasMapAccessAsync(mapId, characterId, corpId, allianceId)).ReturnsAsync(true);
 
-            // Act
             var result = await _service.HasMapAccessAsync(instanceId, mapId, characterId, corpId, allianceId);
 
-            // Assert
             Assert.True(result);
             _mapAccessRepoMock.Verify(r => r.HasMapAccessAsync(mapId, characterId, corpId, allianceId), Times.Once);
         }
@@ -1183,10 +1070,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.IsInstanceAdminAsync(instanceId, characterId)).ReturnsAsync(false);
             _mapAccessRepoMock.Setup(r => r.HasMapAccessAsync(mapId, characterId, corpId, allianceId)).ReturnsAsync(false);
 
-            // Act
             var result = await _service.HasMapAccessAsync(instanceId, mapId, characterId, corpId, allianceId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -1200,7 +1085,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.MapHasAccessRestrictionsAsync(mapId);
 
-            // Assert
             Assert.True(result);
         }
 
@@ -1214,7 +1098,6 @@ namespace WHMapper.Tests.Services.EveMapper
             // Act
             var result = await _service.MapHasAccessRestrictionsAsync(mapId);
 
-            // Assert
             Assert.False(result);
         }
 
@@ -1226,10 +1109,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _instanceRepoMock.Setup(r => r.GetByOwnerAsync(ownerEntityId)).ReturnsAsync((WHInstance?)null);
             _instanceRepoMock.Setup(r => r.Create(It.IsAny<WHInstance>())).ReturnsAsync((WHInstance?)null);
 
-            // Act
             var result = await _service.CreateInstanceAsync("Name", "Desc", ownerEntityId, "Owner", WHAccessEntity.Character, 5701, "Creator");
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -1240,10 +1121,8 @@ namespace WHMapper.Tests.Services.EveMapper
             var ownerEntityId = 5800;
             _instanceRepoMock.Setup(r => r.GetByOwnerAsync(ownerEntityId)).ThrowsAsync(new Exception("Test exception"));
 
-            // Act
             var result = await _service.CreateInstanceAsync("Name", "Desc", ownerEntityId, "Owner", WHAccessEntity.Character, 5801, "Creator");
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -1262,10 +1141,8 @@ namespace WHMapper.Tests.Services.EveMapper
             _mapAccessRepoMock.Setup(r => r.RemoveMapAccessesByEntityAsync(instanceId, access.EveEntityId, access.EveEntity)).ReturnsAsync(emptyMapAccesses);
             _instanceRepoMock.Setup(r => r.RemoveInstanceAccessAsync(instanceId, accessId)).ReturnsAsync(true);
 
-            // Act
             var (success, removed) = await _service.RemoveAccessAsync(instanceId, accessId, requestingCharacterId);
 
-            // Assert
             Assert.True(success);
             Assert.Empty(removed);
         }

--- a/src/WHMapper.Tests/Services/EveMapper/EveMapperUserManagementServiceTest.cs
+++ b/src/WHMapper.Tests/Services/EveMapper/EveMapperUserManagementServiceTest.cs
@@ -41,11 +41,9 @@ public class EveMapperUserManagementServiceTest
         _mockWHMapRepository = new Mock<IWHMapRepository>();
         _mockAccessHelper = new Mock<IEveMapperAccessHelper>();
 
-        // Setup the scoped service provider to return the IWHMapRepository
         _mockScopedServiceProvider.Setup(sp => sp.GetService(typeof(IWHMapRepository))).Returns(_mockWHMapRepository.Object);
         _mockScopedServiceProvider.Setup(sp => sp.GetService(typeof(IEveMapperAccessHelper))).Returns(_mockAccessHelper.Object);
 
-        // Setup the service scope to return the scoped service provider
         _mockServiceScope.Setup(s => s.ServiceProvider).Returns(_mockScopedServiceProvider.Object);
         _mockServiceScopeFactory.Setup(f => f.CreateScope()).Returns(_mockServiceScope.Object);
         _mockServiceProvider.Setup(sp => sp.GetService(typeof(IServiceScopeFactory))).Returns(_mockServiceScopeFactory.Object);
@@ -73,7 +71,6 @@ public class EveMapperUserManagementServiceTest
         // Act
         var result = await _service.GetAccountsAsync(clientId);
 
-        // Assert
         Assert.NotNull(result);
         Assert.Equal(2, result.Length);
         Assert.Contains(result, user => user.Id == 1);
@@ -89,7 +86,6 @@ public class EveMapperUserManagementServiceTest
         // Act
         var result = await _service.GetAccountsAsync(clientId);
 
-        // Assert
         Assert.NotNull(result);
         Assert.Empty(result);
     }
@@ -464,7 +460,6 @@ public async Task SetPrimaryAccountAsync_ShouldThrowException_WhenAccountDoesNot
         // Act
         var result = await _service.GetPrimaryAccountAsync(clientId);
 
-        // Assert
         Assert.NotNull(result);
         Assert.Equal(456, result.Id);
         Assert.True(result.IsPrimary);
@@ -491,7 +486,6 @@ public async Task SetPrimaryAccountAsync_ShouldThrowException_WhenAccountDoesNot
         // Act
         var result = await _service.GetPrimaryAccountAsync(clientId);
 
-        // Assert
         Assert.Null(result);
     }
 
@@ -545,7 +539,6 @@ public async Task SetPrimaryAccountAsync_ShouldThrowException_WhenAccountDoesNot
         // Act
         await _service.UpdateAccountsMapAccessAsync(clientId);
 
-        // Assert
         Assert.True(users[0].HasMapAccess); // primary always true
         Assert.True(users[1].HasMapAccess); // secondary has access to at least one map
     }
@@ -573,7 +566,6 @@ public async Task SetPrimaryAccountAsync_ShouldThrowException_WhenAccountDoesNot
         // Act
         await _service.UpdateAccountsMapAccessAsync(clientId);
 
-        // Assert
         Assert.True(users[0].HasMapAccess);
         Assert.False(users[1].HasMapAccess);
     }
@@ -614,7 +606,6 @@ public async Task SetPrimaryAccountAsync_ShouldThrowException_WhenAccountDoesNot
         // Act
         await _service.UpdateAccountsCurrentMapAccessAsync(clientId, mapId);
 
-        // Assert
         Assert.True(users[0].HasCurrentMapAccess);
         Assert.False(users[1].HasCurrentMapAccess);
     }
@@ -643,7 +634,6 @@ public async Task SetPrimaryAccountAsync_ShouldThrowException_WhenAccountDoesNot
         // Act
         var ex = await Record.ExceptionAsync(() => _service.UpdateAccountsCurrentMapAccessAsync(clientId, mapId));
 
-        // Assert
         Assert.Null(ex); // Should not throw
     }
     

--- a/src/WHMapper.Tests/Services/EveOnlineAPI/PublicEveOnlineAPITest.cs
+++ b/src/WHMapper.Tests/Services/EveOnlineAPI/PublicEveOnlineAPITest.cs
@@ -108,21 +108,18 @@ public class PublicEveOnlineAPITest
     public async Task Get_Universe_System_Constellation_Region_Star_And_Stargate()
     {
         Assert.NotNull(_eveUniverseApi);
-        //getsystems
         var systemsResult = await _eveUniverseApi.GetSystems();
         int[]? systems = systemsResult?.Data;
         Assert.NotNull(systems);
         Assert.NotEmpty(systems);
         Assert.Contains(systems, item => SOLAR_SYSTEM_JITA_ID==item);
 
-        //constellations
         var constellationsResult = await _eveUniverseApi.GetContellations();
         int[]? constellations = constellationsResult?.Data;
         Assert.NotNull(constellations);
         Assert.NotEmpty(constellations);
         Assert.Contains(constellations, item => CONSTELLATION_ID == item);
 
-        //regions
         var regionsResult = await _eveUniverseApi.GetRegions();
         int[]? regions = regionsResult?.Data;
         Assert.NotNull(regions);
@@ -208,14 +205,12 @@ public class PublicEveOnlineAPITest
         Assert.NotNull(sunGroups);
         Assert.Equal(SUN_GROUP_NAME, sunGroups.Name);
 
-        //planet
         Assert.Contains<int>(GROUP_PLANET_ID, groups);
         var planetGroupsResult = await _eveUniverseApi.GetGroup(GROUP_PLANET_ID);
         var planetGroups = planetGroupsResult?.Data;
         Assert.NotNull(planetGroups);
         Assert.Equal(PLANET_GROUP_NAME, planetGroups.Name);
 
-        //wormhole
         //has been removed ??? but always accessible if you get group with GROUP_WORMHOLE_ID
         // Assert.Contains<int>(GROUP_WORMHOLE_ID, groups);
         var whGroupsResult = await _eveUniverseApi.GetGroup(GROUP_WORMHOLE_ID);

--- a/src/WHMapper.Tests/Services/OAuth/ClaimServicesTest.cs
+++ b/src/WHMapper.Tests/Services/OAuth/ClaimServicesTest.cs
@@ -29,9 +29,7 @@ public class ClaimServicesTest
     [Fact]
     public async Task ExtractClaimsFromEVEToken_ValidToken_ReturnsClaims()
     {
-        // Act
         var result = await _claimServices.ExtractClaimsFromEVEToken(_token);
-        // Assert
         Assert.Contains(result, claim => claim.Type == ClaimTypes.Name && claim.Value == "Skototounta");
     }
 
@@ -39,7 +37,7 @@ public class ClaimServicesTest
     public async Task ExtractClaimsFromEVEToken_NullOrEmptyToken_ThrowsArgumentNullException()
     {
         // Act & Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(() => _claimServices.ExtractClaimsFromEVEToken(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _claimServices.ExtractClaimsFromEVEToken(null!));
         await Assert.ThrowsAsync<ArgumentNullException>(() => _claimServices.ExtractClaimsFromEVEToken(string.Empty));
     }
 
@@ -48,7 +46,7 @@ public class ClaimServicesTest
     {
         // Arrange
         var token = "invalid-token";
-        _mockTokenHandler.Setup(handler => handler.ReadJsonWebToken(token)).Returns((JsonWebToken)null);
+        _mockTokenHandler.Setup(handler => handler.ReadJsonWebToken(token)).Returns((JsonWebToken)null!);
 
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() => _claimServices.ExtractClaimsFromEVEToken(token));

--- a/src/WHMapper.Tests/Services/OAuth/EveOnlineTokenProviderTest.cs
+++ b/src/WHMapper.Tests/Services/OAuth/EveOnlineTokenProviderTest.cs
@@ -73,7 +73,6 @@ public class EveOnlineTokenProviderTest
         // Act
         var retrievedToken = await _tokenProvider.GetToken("test-account-id");
 
-        // Assert
         Assert.Equal(token, retrievedToken);
     }
 
@@ -83,7 +82,6 @@ public class EveOnlineTokenProviderTest
         // Act
         var retrievedToken = await _tokenProvider.GetToken("non-existing-account-id");
 
-        // Assert
         Assert.Null(retrievedToken);
     }
 
@@ -112,7 +110,6 @@ public class EveOnlineTokenProviderTest
         // Act
         var isExpired = await _tokenProvider.IsTokenExpire("test-account-id");
 
-        // Assert
         Assert.True(isExpired);
     }
 
@@ -126,7 +123,6 @@ public class EveOnlineTokenProviderTest
         // Act
         var isExpired = await _tokenProvider.IsTokenExpire("test-account-id");
 
-        // Assert
         Assert.False(isExpired);
     }
 
@@ -156,6 +152,7 @@ public class EveOnlineTokenProviderTest
 
         // Assert
         var refreshedToken = await _tokenProvider.GetToken("test-account-id");
+        Assert.NotNull(refreshedToken);
         Assert.Equal(newToken.AccessToken, refreshedToken.AccessToken);
         Assert.Equal(newToken.RefreshToken, refreshedToken.RefreshToken);
     }

--- a/src/WHMapper.Tests/Services/OAuth/EveUserInfosServicesTest.cs
+++ b/src/WHMapper.Tests/Services/OAuth/EveUserInfosServicesTest.cs
@@ -35,7 +35,6 @@ public class EveUserInfosServicesTest
         // Act
         var result = await _eveUserInfosServices.GetUserName();
 
-        // Assert
         Assert.Equal("TestUser", result);
     }
 
@@ -51,7 +50,6 @@ public class EveUserInfosServicesTest
         // Act
         var result = await _eveUserInfosServices.GetUserName();
 
-        // Assert
         Assert.Equal(IEveUserInfosServices.ANONYMOUS_USERNAME, result);
     }
 
@@ -67,10 +65,8 @@ public class EveUserInfosServicesTest
         _mockAuthenticationStateProvider.Setup(provider => provider.GetAuthenticationStateAsync())
             .ReturnsAsync(authState);
 
-        // Act
         var result = await _eveUserInfosServices.GetCharactedID();
 
-        // Assert
         Assert.Equal(12345, result);
     }
 
@@ -86,10 +82,8 @@ public class EveUserInfosServicesTest
         _mockAuthenticationStateProvider.Setup(provider => provider.GetAuthenticationStateAsync())
             .ReturnsAsync(authState);
 
-        // Act
         var result = await _eveUserInfosServices.GetCharactedID();
 
-        // Assert
         Assert.Equal(0, result);
     }
 
@@ -102,10 +96,8 @@ public class EveUserInfosServicesTest
         _mockAuthenticationStateProvider.Setup(provider => provider.GetAuthenticationStateAsync())
             .ReturnsAsync(authState);
 
-        // Act
         var result = await _eveUserInfosServices.GetCharactedID();
 
-        // Assert
         Assert.Equal(0, result);
     }
 }

--- a/src/WHMapper.Tests/Services/SDE/SDEInitializationStateTest.cs
+++ b/src/WHMapper.Tests/Services/SDE/SDEInitializationStateTest.cs
@@ -224,7 +224,7 @@ public class SDEInitializationStateTest
 
         await Task.WhenAll(tasks);
 
-        Assert.Single(results.Where(r => r));
+        Assert.Single(results, r => r);
         Assert.Equal(9, results.Count(r => !r));
     }
 

--- a/src/WHMapper.Tests/Services/SDE/SDEServiceTest.cs
+++ b/src/WHMapper.Tests/Services/SDE/SDEServiceTest.cs
@@ -35,7 +35,6 @@ namespace WHMapper.Tests.Services.SDE
             // Act
             var result = await _sdeService.GetSolarSystemList();
 
-            // Assert
             Assert.NotNull(result);
             Assert.Single(result);
             Assert.Equal("TestSystem", result.First().Name);
@@ -52,7 +51,6 @@ namespace WHMapper.Tests.Services.SDE
             // Act
             var result = await _sdeService.GetSolarSystemList();
 
-            // Assert
             Assert.NotNull(result);
             Assert.Empty(result);
         }
@@ -68,7 +66,6 @@ namespace WHMapper.Tests.Services.SDE
             // Act
             var result = await _sdeService.GetSolarSystemList();
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -87,7 +84,6 @@ namespace WHMapper.Tests.Services.SDE
             // Act
             var result = await _sdeService.SearchSystemById(1);
 
-            // Assert
             Assert.NotNull(result);
             Assert.Equal(1, result.SolarSystemID);
         }
@@ -107,7 +103,6 @@ namespace WHMapper.Tests.Services.SDE
             // Act
             var result = await _sdeService.SearchSystemById(2);
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -127,7 +122,6 @@ namespace WHMapper.Tests.Services.SDE
             // Act
             var result = await _sdeService.SearchSystem("Test");
 
-            // Assert
             Assert.NotNull(result);
             Assert.Single(result);
             Assert.Equal("TestSystem", result.First().Name);
@@ -139,7 +133,6 @@ namespace WHMapper.Tests.Services.SDE
             // Act
             var result = await _sdeService.SearchSystem("");
 
-            // Assert
             Assert.Null(result);
         }
 
@@ -154,7 +147,6 @@ namespace WHMapper.Tests.Services.SDE
             // Act
             var result = await _sdeService.SearchSystem("Test");
 
-            // Assert
             Assert.Null(result);
         }
     }

--- a/src/WHMapper.Tests/Services/SDE/SdeServiceManagerIntegrationTests.cs
+++ b/src/WHMapper.Tests/Services/SDE/SdeServiceManagerIntegrationTests.cs
@@ -48,7 +48,7 @@ public class SdeServiceManagerIntegrationTests
 
         ICacheService cacheService = new CacheService(new NullLogger<CacheService>(), _distriCache);
 
-        HttpClient httpClient = new HttpClient() { BaseAddress = new Uri(configuration.GetValue<string>("SdeDataSupplier:BaseUrl")) };
+        HttpClient httpClient = new HttpClient() { BaseAddress = new Uri(configuration.GetValue<string>("SdeDataSupplier:BaseUrl")!) };
         ISDEDataSupplier sDEDataSupplier = new SdeDataSupplier(new NullLogger<SdeDataSupplier>(), httpClient);
 
         SDEServiceManager = new SDEServiceManager(new NullLogger<SDEServiceManager>(), sDEDataSupplier, cacheService);

--- a/src/WHMapper.Tests/WHHelper/EveWHAccessHelperTest.cs
+++ b/src/WHMapper.Tests/WHHelper/EveWHAccessHelperTest.cs
@@ -23,7 +23,6 @@ public class EveWHAccessHelperTest
     private int EVE_CHARACTERE_ID2 = 153110579;
 
     private int EVE_CORPO_ID = 1344654522;
-    private int EVE_ALLIANCE_ID = 1354830081;
 
     IDbContextFactory<WHMapperContext>? _contextFactory;
     private IEveMapperAccessHelper? _accessHelper;
@@ -36,7 +35,6 @@ public class EveWHAccessHelperTest
     public EveWHAccessHelperTest()
     {
 
-        //Create DB Context
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json")
             .AddEnvironmentVariables()
@@ -123,7 +121,6 @@ public class EveWHAccessHelperTest
         var noAccess = await _accessHelper.IsEveMapperUserAccessAuthorized(EVE_CHARACTERE_ID2);
         Assert.False(noAccess);
 
-        // Cleanup
         await _whInstanceRepository.DeleteById(createdInstance.Id);
     }
 
@@ -153,7 +150,6 @@ public class EveWHAccessHelperTest
         var noAccess = await _accessHelper.IsEveMapperUserAccessAuthorized(EVE_CHARACTERE_ID2);
         Assert.False(noAccess);
 
-        // Cleanup
         await _whInstanceRepository.DeleteById(createdInstance.Id);
     }
 
@@ -186,7 +182,6 @@ public class EveWHAccessHelperTest
         var nowAdmin = await _accessHelper.IsEveMapperAdminAccessAuthorized(EVE_CHARACTERE_ID2);
         Assert.True(nowAdmin);
 
-        // Cleanup
         await _whInstanceRepository.DeleteById(createdInstance.Id);
     }
 
@@ -221,7 +216,6 @@ public class EveWHAccessHelperTest
         var noAccess = await _accessHelper.IsEveMapperMapAccessAuthorized(EVE_CHARACTERE_ID2, map.Id);
         Assert.False(noAccess);
 
-        // Cleanup
         await _whMapRepository.DeleteById(map.Id);
         await _whInstanceRepository.DeleteById(createdInstance.Id);
     }

--- a/src/WHMapper.Tests/WHHelper/EveWHMapperEntityTest.cs
+++ b/src/WHMapper.Tests/WHHelper/EveWHMapperEntityTest.cs
@@ -58,7 +58,6 @@ public class EveWHMapperEntityTest
 
     public EveWHMapperEntityTest()
     {
-        //Create DB Context
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json")
             .AddEnvironmentVariables()

--- a/src/WHMapper.Tests/WHHelper/EveWHMapperHelperTest.cs
+++ b/src/WHMapper.Tests/WHHelper/EveWHMapperHelperTest.cs
@@ -95,7 +95,6 @@ public class EveWHMapperHelperTest
 
     public EveWHMapperHelperTest()
     {
-        //Create DB Context
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json")
             .AddEnvironmentVariables()
@@ -144,7 +143,7 @@ public class EveWHMapperHelperTest
             IFileSystem fileSystem = new FileSystem();
 
             var sdeHttpClient = httpclientfactory.CreateClient();
-            sdeHttpClient.BaseAddress = new Uri(configuration.GetValue<string>("SdeDataSupplier:BaseUrl"));
+            sdeHttpClient.BaseAddress = new Uri(configuration.GetValue<string>("SdeDataSupplier:BaseUrl")!);
             ISDEDataSupplier dataSupplier = new SdeDataSupplier(loggerSdeDataSupplier, sdeHttpClient);
 
             ISDEService sDEServices = new SDEService(loggerSDE, cacheService);

--- a/src/WHMapper.Tests/WHHelper/EveWHMapperRoutePlannerHelperTest.cs
+++ b/src/WHMapper.Tests/WHHelper/EveWHMapperRoutePlannerHelperTest.cs
@@ -98,9 +98,7 @@ public class EveWHMapperRoutePlannerHelperTest
         };
     }
 
-    // ===========================================================
     // AddRoute
-    // ===========================================================
 
     [Fact]
     public async Task AddRoute_Global_True_CallsCreateWithoutEntityId()
@@ -167,9 +165,7 @@ public class EveWHMapperRoutePlannerHelperTest
         Assert.Null(result);
     }
 
-    // ===========================================================
     // DeleteRoute
-    // ===========================================================
 
     [Fact]
     public async Task DeleteRoute_ReturnsTrue_WhenRepositoryReturnsTrue()
@@ -194,9 +190,7 @@ public class EveWHMapperRoutePlannerHelperTest
         Assert.False(result);
     }
 
-    // ===========================================================
     // GetMyRoutes
-    // ===========================================================
 
     [Fact]
     public async Task GetMyRoutes_NoClientId_ReturnsNull()
@@ -245,9 +239,7 @@ public class EveWHMapperRoutePlannerHelperTest
         _routeRepoMock.Verify(r => r.GetRoutesForAll(It.IsAny<int>()), Times.Never);
     }
 
-    // ===========================================================
     // GetRoutesForAll
-    // ===========================================================
 
     [Fact]
     public async Task GetRoutesForAll_RepositoryNull_ReturnsNull()
@@ -313,9 +305,7 @@ public class EveWHMapperRoutePlannerHelperTest
         Assert.Equal(string.Empty, route.DestinationName);
     }
 
-    // ===========================================================
     // GetTheraRoutes / GetTurnurRoutes
-    // ===========================================================
 
     [Fact]
     public async Task GetTheraRoutes_NoEntries_ReturnsEmpty()
@@ -422,9 +412,7 @@ public class EveWHMapperRoutePlannerHelperTest
         _eveScoutMock.Verify(e => e.GetTheraSystemsAsync(), Times.Never);
     }
 
-    // ===========================================================
     // CalculateRoute (via GetRoutesForAll)
-    // ===========================================================
 
     private void SetupSingleDestination(int destinationSystemId)
     {

--- a/src/WHMapper.Tests/WHMapper.Tests.csproj
+++ b/src/WHMapper.Tests/WHMapper.Tests.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
-    <PackageReference Include="Testably.Abstractions.Compression" Version="6.6.0" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
+    <PackageReference Include="Testably.Abstractions.Compression" Version="7.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -29,13 +29,13 @@
     <PackageReference Include="Npgsql" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.*" />
     <PackageReference Include="Xunit.Priority" Version="1.1.6" />
-    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.17.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="appsettings.json" Condition="'$(ExcludeConfigFilesFromBuildOutput)'!='true'">

--- a/src/WHMapper/Components/Pages/Home.razor.cs
+++ b/src/WHMapper/Components/Pages/Home.razor.cs
@@ -58,10 +58,8 @@ public partial class Home : ComponentBase, IAsyncDisposable
             SDEInitializationState.OnInitializationCompleted += OnSDEInitializationCompleted;
         }
 
-        // Subscribe to instance access events
         await InitRealTimeServiceEvents();
 
-        // Subscribe to primary account changes to refresh authorization state
         UserManagement.PrimaryAccountChanged += OnPrimaryAccountChanged;
 
         // In single-tenant mode, once an instance exists, creation is locked
@@ -97,7 +95,6 @@ public partial class Home : ComponentBase, IAsyncDisposable
             {
                 if (_isWaitingForOtherInitialization)
                 {
-                    // Wait for the other initialization to complete
                     await WaitForOtherInitializationAsync();
                 }
                 else
@@ -133,7 +130,6 @@ public partial class Home : ComponentBase, IAsyncDisposable
         {
             await SDEInitializationState.WaitForInitializationAsync();
             
-            // Verify the SDE was successfully extracted
             if (SDEServices.IsExtractionSuccesful())
             {
                 await SetLoading(false);
@@ -147,7 +143,6 @@ public partial class Home : ComponentBase, IAsyncDisposable
         }
         catch (TaskCanceledException)
         {
-            // Handle cancellation gracefully
             await SetLoading(false);
         }
     }
@@ -186,12 +181,10 @@ public partial class Home : ComponentBase, IAsyncDisposable
             if (primaryAccount.Id == accountID)
                 return;
 
-            // Refresh the page to re-evaluate the authorization
             // The policy will check if we now have access
             Snackbar.Add("You have been granted access to an instance! Refreshing...", Severity.Success);
             await InvokeAsync(async () =>
             {
-                // Force page reload to re-evaluate authorization
                 await JSRuntime.InvokeVoidAsync("window.location.replace", "/");
             });
         }
@@ -218,12 +211,10 @@ public partial class Home : ComponentBase, IAsyncDisposable
             if (primaryAccount.Id == accountID)
                 return;
 
-            // Refresh the page to re-evaluate the authorization
             // The policy will check if we still have access
             Snackbar.Add("Your access to an instance has been revoked. Refreshing...", Severity.Warning);
             await InvokeAsync(async () =>
             {
-                // Force page reload to re-evaluate authorization
                 await JSRuntime.InvokeVoidAsync("window.location.replace", "/");
             });
         }
@@ -237,11 +228,9 @@ public partial class Home : ComponentBase, IAsyncDisposable
     {
         try
         {
-            // Only react to changes for our client
             if (clientId != UID.ClientId)
                 return;
 
-            // Force page reload to re-evaluate authorization
             // The new primary account may have different instance access
             await InvokeAsync(async () =>
             {
@@ -266,10 +255,8 @@ public partial class Home : ComponentBase, IAsyncDisposable
             RealTimeService.InstanceAccessRemoved -= OnInstanceAccessRemoved;
         }
 
-        // Unsubscribe from primary account changes
         UserManagement.PrimaryAccountChanged -= OnPrimaryAccountChanged;
 
-        // Unsubscribe from SDE initialization events
         SDEInitializationState.OnProgressChanged -= OnSDEProgressChanged;
         SDEInitializationState.OnInitializationCompleted -= OnSDEInitializationCompleted;
 
@@ -303,11 +290,9 @@ public partial class Home : ComponentBase, IAsyncDisposable
 
     private async Task DownloadExtractImportSDE()
     {
-        // Try to acquire the initialization lock
         if (!SDEInitializationState.TryAcquireInitializationLock())
         {
             // Another user started initialization between our check and now
-            // Subscribe to progress updates and wait
             _isWaitingForOtherInitialization = true;
             _init_process_msg = SDEInitializationState.CurrentProgressMessage;
             SDEInitializationState.OnProgressChanged += OnSDEProgressChanged;
@@ -356,7 +341,6 @@ public partial class Home : ComponentBase, IAsyncDisposable
         }
         finally
         {
-            // Always release the lock when done
             SDEInitializationState.ReleaseInitializationLock();
         }
     }

--- a/src/WHMapper/Components/Pages/Instance/AdminInstanceDialog.razor
+++ b/src/WHMapper/Components/Pages/Instance/AdminInstanceDialog.razor
@@ -90,12 +90,12 @@
                                                     <MudIconButton Icon="@Icons.Material.Filled.Security" 
                                                                    Color="Color.Info" 
                                                                    Size="Size.Small"
-                                                                   Title="Manage Access"
+                                                                   title="Manage Access"
                                                                    OnClick="@(() => ManageMapAccess(map))" />
                                                     <MudIconButton Icon="@Icons.Material.Filled.Delete" 
                                                                    Color="Color.Error" 
                                                                    Size="Size.Small"
-                                                                   Title="Delete Map"
+                                                                   title="Delete Map"
                                                                    OnClick="@(() => DeleteMap(map))" />
                                                 </MudStack>
                                             </MudStack>

--- a/src/WHMapper/Components/Pages/Instance/AdminInstanceDialog.razor.cs
+++ b/src/WHMapper/Components/Pages/Instance/AdminInstanceDialog.razor.cs
@@ -252,7 +252,7 @@ public partial class AdminInstanceDialog
             {
                 foreach (var removedAccessId in mapAccess.Value)
                 {
-                    await RealTimeService.NotifyMapAccessRemoved(_characterId, mapAccess.Key, removedAccessId);
+                    await RealTimeService.NotifyMapAccessRemoved(_characterId, InstanceId, mapAccess.Key, removedAccessId);
                 }
             }
             

--- a/src/WHMapper/Components/Pages/Instance/InstancesDialog.razor.cs
+++ b/src/WHMapper/Components/Pages/Instance/InstancesDialog.razor.cs
@@ -122,7 +122,6 @@ public partial class InstancesDialog
         var dialog = await DialogService.ShowAsync<AdminInstanceDialog>("Manage Instance", parameters, options);
         await dialog.Result;
         
-        // Reload instances after admin dialog closes in case of changes
         await LoadInstancesAsync();
 
         // Auto-close if no instances remain (e.g. last instance was deleted)
@@ -148,7 +147,6 @@ public partial class InstancesDialog
         var dialog = await DialogService.ShowAsync<RegisterInstanceDialog>("Create Instance", options);
         await dialog.Result;
         
-        // Reload instances after creation dialog closes
         await LoadInstancesAsync();
         StateHasChanged();
     }

--- a/src/WHMapper/Components/Pages/Instance/MapAccessDialog.razor.cs
+++ b/src/WHMapper/Components/Pages/Instance/MapAccessDialog.razor.cs
@@ -92,8 +92,7 @@ public partial class MapAccessDialog : ComponentBase
             {
                 Snackbar.Add($"Granted map access to {instanceAccess.EveEntityName}", Severity.Success);
                 
-                // Notify all connected users about the new map access
-                await RealTimeService.NotifyMapAccessesAdded(_characterId, Map.Id, new[] { result.Id });
+                await RealTimeService.NotifyMapAccessesAdded(_characterId, InstanceId, Map.Id, new[] { result.Id });
                 
                 await LoadMapAccessesAsync();
                 StateHasChanged();
@@ -132,8 +131,7 @@ public partial class MapAccessDialog : ComponentBase
                 {
                     Snackbar.Add("Map access removed successfully", Severity.Success);
                     
-                    // Notify all connected users about the removed map access
-                    await RealTimeService.NotifyMapAccessRemoved(_characterId, Map.Id, accessId);
+                    await RealTimeService.NotifyMapAccessRemoved(_characterId, InstanceId, Map.Id, accessId);
                     
                     await LoadMapAccessesAsync();
                     StateHasChanged();
@@ -172,8 +170,7 @@ public partial class MapAccessDialog : ComponentBase
                 {
                     Snackbar.Add("All map access restrictions removed", Severity.Success);
                     
-                    // Notify all connected users that all map accesses have been removed
-                    await RealTimeService.NotifyMapAllAccessesRemoved(_characterId, Map.Id);
+                    await RealTimeService.NotifyMapAllAccessesRemoved(_characterId, InstanceId, Map.Id);
                     
                     await LoadMapAccessesAsync();
                     StateHasChanged();

--- a/src/WHMapper/Components/Pages/Mapper/CustomNode/EveSystemNode.razor
+++ b/src/WHMapper/Components/Pages/Mapper/CustomNode/EveSystemNode.razor
@@ -51,11 +51,11 @@
         <MudStack Row="true" Style="width:100%;" Spacing="0" Class="ml-2 mr-2">
             @if (_isEditingName)
             {
-                <MudTextField @bind-Value="_editedName" Typo="Typo.body2" Align="Align.Center"
+                <MudTextField @bind-Value="_editedName" Typo="Typo.body2"
                               Immediate="true"
                               @onblur="@(() => SaveName())"
                               @onkeyup="@((e) => OnKeyUp(e))"
-                              Style="font-weight:bold; width:99%;"
+                              Style="font-weight:bold; width:99%; text-align:center;"
                               Variant="Variant.Text"
                               Margin="Margin.Dense"
                               AutoFocus="true" />

--- a/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
@@ -1086,9 +1086,9 @@ public partial class Overview : IAsyncDisposable
             }
 
             var whLink = _blazorDiagram.Links.FirstOrDefault(x =>
-            ((((EveSystemNodeModel)x.Source!.Model!).IdWH == src.IdWH) && (((EveSystemNodeModel)x.Target!.Model!).IdWH == target.IdWH))
+            ((((EveSystemNodeModel)x.Source.Model!).IdWH == src.IdWH) && (((EveSystemNodeModel)x.Target.Model!).IdWH == target.IdWH))
             ||
-            ((((EveSystemNodeModel)x.Source!.Model!).IdWH == target.IdWH) && (((EveSystemNodeModel)x.Target!.Model!).IdWH == src.IdWH)));
+            ((((EveSystemNodeModel)x.Source.Model).IdWH == target.IdWH) && (((EveSystemNodeModel)x.Target.Model!).IdWH == src.IdWH)));
 
             return Task.FromResult(whLink as EveSystemLinkModel);
         }
@@ -1364,7 +1364,7 @@ public partial class Overview : IAsyncDisposable
         {
             //get whClass an determine if another connection to another wh with same class exist from previous system. 
             EveSystemType whClass = await MapperServices.GetWHClass(targetEntity);
-            var sameWHClassWHList = _blazorDiagram?.Links?.Where(x => ((EveSystemNodeModel)(x.Target!.Model!)).SystemType == whClass && ((EveSystemNodeModel)x.Source!.Model!).SolarSystemId == srcEntity.Id);
+            var sameWHClassWHList = _blazorDiagram?.Links?.Where(x => ((EveSystemNodeModel)(x.Target.Model!)).SystemType == whClass && ((EveSystemNodeModel)x.Source.Model!).SolarSystemId == srcEntity.Id);
 
             if (sameWHClassWHList != null)
                 countSameWHClassLink = sameWHClassWHList.Count();
@@ -1572,13 +1572,11 @@ public partial class Overview : IAsyncDisposable
                     targetNode = await GetNodeBySolarSystemId(newLocation.SolarSystemId);
 
 
-                    if (srcNode != null && targetNode != null && !await IsLinkExist(srcNode, targetNode))
+                    if (srcNode != null && targetNode != null && !await IsLinkExist(srcNode, targetNode)
+                        && !await AddSystemNodeLink(mapId, srcNode, targetNode, accountID))//create if new target system added from src
                     {
-                        if (!await AddSystemNodeLink(mapId, srcNode, targetNode, accountID))//create if new target system added from src
-                        {
-                            Logger.LogError("Add Wormhole Link error");
-                            Snackbar?.Add("Add Wormhole Link error", Severity.Error);
-                        }
+                        Logger.LogError("Add Wormhole Link error");
+                        Snackbar?.Add("Add Wormhole Link error", Severity.Error);
                     }
                 }
             }
@@ -1610,7 +1608,7 @@ public partial class Overview : IAsyncDisposable
             CharacterEntity? user = await eveMapperService.GetCharacter(accountID);
             if (user != null)
             {
-                EveSystemNodeModel? userSystem = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x)!.ConnectedUsers.Contains(user.Name));
+                EveSystemNodeModel? userSystem = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).ConnectedUsers.Contains(user.Name));
                 if (userSystem != null)
                 {
                     await userSystem.RemoveConnectedUser(user.Name);
@@ -2029,7 +2027,7 @@ public partial class Overview : IAsyncDisposable
             if (user == null)
                 throw new NullReferenceException("User not found");
 
-            EveSystemNodeModel? userSystem = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x)!.ConnectedUsers.Contains(user.Name));
+            EveSystemNodeModel? userSystem = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).ConnectedUsers.Contains(user.Name));
             if (userSystem != null)
             {
                 await userSystem.RemoveConnectedUser(user.Name);
@@ -2059,14 +2057,14 @@ public partial class Overview : IAsyncDisposable
                 if (user == null)
                     throw new NullReferenceException("User not found");
 
-                EveSystemNodeModel? userSystem = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x)!.ConnectedUsers.Contains(user.Name));
+                EveSystemNodeModel? userSystem = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).ConnectedUsers.Contains(user.Name));
                 if (userSystem != null && userSystem.IdWH != wormholeId)
                 {
                     await userSystem.RemoveConnectedUser(user.Name);
                     userSystem.Refresh();
                 }
 
-                EveSystemNodeModel? systemToAddUser = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x)!.IdWH == wormholeId);
+                EveSystemNodeModel? systemToAddUser = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x).IdWH == wormholeId);
                 if (systemToAddUser != null && systemToAddUser.ConnectedUsers != null && !systemToAddUser.ConnectedUsers.Contains(user.Name))
                 {
                     await systemToAddUser.AddConnectedUser(user.Name);

--- a/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
@@ -170,7 +170,6 @@ public partial class Overview : IAsyncDisposable
             Snackbar?.Add("Map Initialization error", Severity.Error);
         }
 
-        // Load real user settings and apply to the already-created diagram
         var primaryAccount = await GetPrimaryAccountAsync();
         _userSettings = await UserSettingService.GetSettingsAsync(primaryAccount?.Id ?? 0);
         ApplyUserSettingsToDiagram();
@@ -240,8 +239,10 @@ public partial class Overview : IAsyncDisposable
         {
             if (await Restore(MapId.Value, cancellationToken))
             {
-                // Update current map access for all accounts
-                await UserManagement.UpdateAccountsCurrentMapAccessAsync(UID.ClientId, MapId.Value);
+                if (!string.IsNullOrEmpty(UID.ClientId))
+                    await UserManagement.UpdateAccountsCurrentMapAccessAsync(UID.ClientId, MapId.Value);
+                else
+                    Logger.LogWarning("LoadMapAsync: no client id, skipping current map access update");
                 
                 WHMapperUser[]? accounts = await GetAccountsAsync();
                 if (accounts != null)
@@ -254,7 +255,6 @@ public partial class Overview : IAsyncDisposable
                             return;
                         }
 
-                        // Check if account has access to this specific map
                         if (!account.HasCurrentMapAccess)
                         {
                             Logger.LogInformation("Account {AccountId} does not have access to map {MapId}, disabling tracking", account.Id, MapId.Value);
@@ -265,6 +265,10 @@ public partial class Overview : IAsyncDisposable
                             }
                             continue; // Skip this account for user position and tracking
                         }
+
+                        // Join first: positions are scoped server-side to the maps this connection
+                        // has been authorized to join, so joining has to happen before reading them.
+                        await EveMapperRealTime.JoinMap(account.Id, MapId.Value);
 
                         IDictionary<int, KeyValuePair<int, int>?> usersPosition = await EveMapperRealTime.GetConnectedUsersPosition(account.Id);
                         try
@@ -298,7 +302,6 @@ public partial class Overview : IAsyncDisposable
                             Logger.LogError(ex, "On NotifyUserPosition error");
                         }
 
-                        await EveMapperRealTime.JoinMap(account.Id, MapId.Value);
                         await EveMapperRealTime.NotifyUserOnMapConnected(account.Id, MapId.Value);
                         if (account.Tracking)
                         {
@@ -318,7 +321,10 @@ public partial class Overview : IAsyncDisposable
                     // Notify listeners now that the SignalR-side state for this map is consistent.
                     // Firing CurrentMapChanged earlier (e.g. from UpdateAccountsCurrentMapAccessAsync)
                     // races against SendUserOnMapConnected and would leave the connected-users count stale.
-                    await UserManagement.NotifyCurrentMapChangedAsync(UID.ClientId, MapId.Value);
+                    if (!string.IsNullOrEmpty(UID.ClientId))
+                        await UserManagement.NotifyCurrentMapChangedAsync(UID.ClientId, MapId.Value);
+                    else
+                        Logger.LogWarning("LoadMapAsync: no client id, skipping current map changed notification");
                 }
             }
         }
@@ -363,7 +369,6 @@ public partial class Overview : IAsyncDisposable
             return;
         _disposed = true;
         
-        // Cancel pending operations
         if (!_cts.IsCancellationRequested)
         {
             _cts.Cancel();
@@ -372,7 +377,6 @@ public partial class Overview : IAsyncDisposable
 
         UserSettingService.OnSettingsChanged -= OnUserSettingsChangedAsync;
 
-        // Unsubscribe from TrackerServices events
         // Note: Do NOT dispose TrackerServices here - it's a scoped service managed by DI
         // and must remain active for the lifetime of the user session
         if (TrackerServices != null)
@@ -383,7 +387,6 @@ public partial class Overview : IAsyncDisposable
             TrackerServices.TrackingShipRetryRequested -= OnTrackingShipRetryRequested;
         }
 
-        // Unsubscribe from EveMapperRealTime events
         if (EveMapperRealTime != null)
         {
             await LeaveMapGroupsAsync();
@@ -996,7 +999,6 @@ public partial class Overview : IAsyncDisposable
     {
         if (whNodeModel != null)
         {
-            //save name extension to db
             var wh = await DbWHSystems.GetById(whNodeModel.IdWH);
             if (wh != null)
             {
@@ -1113,36 +1115,25 @@ public partial class Overview : IAsyncDisposable
         if (srcNode?.Position == null || srcNode.Size == null)
             return (0, 0);
 
-        // Source node dimensions
         double srcWidth = srcNode.Size.Width;
         double srcHeight = srcNode.Size.Height;
 
-        // New node dimensions (use source dimensions as default estimate)
         double newWidth = newNodeWidth ?? srcWidth;
         double newHeight = newNodeHeight ?? srcHeight;
 
-        // Base position = source node position
         double baseX = srcNode.Position.X;
         double baseY = srcNode.Position.Y;
 
         // 8 candidate positions around the source node (direction name + base displacement)
         var directions = new (double dx, double dy, string name)[]
         {
-            // Right
             (srcWidth + SPACING, (srcHeight - newHeight) / 2, "Right"),
-            // Bottom
             ((srcWidth - newWidth) / 2, srcHeight + SPACING, "Bottom"),
-            // Top
             ((srcWidth - newWidth) / 2, -(newHeight + SPACING), "Top"),
-            // Left
             (-(newWidth + SPACING), (srcHeight - newHeight) / 2, "Left"),
-            // Bottom-Right
             (srcWidth + SPACING, srcHeight + SPACING, "Bottom-Right"),
-            // Top-Right
             (srcWidth + SPACING, -(newHeight + SPACING), "Top-Right"),
-            // Bottom-Left
             (-(newWidth + SPACING), srcHeight + SPACING, "Bottom-Left"),
-            // Top-Left
             (-(newWidth + SPACING), -(newHeight + SPACING), "Top-Left"),
         };
 
@@ -1154,7 +1145,6 @@ public partial class Overview : IAsyncDisposable
                 double candidateX = Math.Max(10, baseX + (dx*attempt));
                 double candidateY = Math.Max(10, baseY + (dy*attempt));
 
-                // Check collision against all existing nodes
                 if (!HasCollision(candidateX, candidateY, newWidth, newHeight, SPACING))
                 {
                     return (candidateX, candidateY);
@@ -1350,7 +1340,6 @@ public partial class Overview : IAsyncDisposable
         if (srcEntity != null && targetEntity != null && await MapperServices.IsRouteViaWH(srcEntity, targetEntity))
         {
             //get whClass an determine if another connection to another wh with same class exist from previous system. 
-            // Increment extension value in that case
             EveSystemType whClass = await MapperServices.GetWHClass(targetEntity);
             var sameWHClassWHList = _blazorDiagram?.Links?.Where(x => ((EveSystemNodeModel)(x.Target!.Model!)).SystemType == whClass && ((EveSystemNodeModel)x.Source!.Model!).SolarSystemId == srcEntity.Id);
 
@@ -1520,6 +1509,13 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnSystemChanged(int accountID, EveLocation? oldLocation, EveLocation newLocation)
     {
+        if (!MapId.HasValue)
+        {
+            Logger.LogWarning("OnSystemChanged: no map loaded, ignoring system change");
+            return;
+        }
+        int mapId = MapId.Value;
+
         EveSystemNodeModel? srcNode = null;
         EveSystemNodeModel? targetNode = null;
 
@@ -1533,13 +1529,11 @@ public partial class Overview : IAsyncDisposable
 
             if (targetNode == null)//location not exist on map
             {
-                //get extension if needed
 
                 char? extension = null;
                 if (oldLocation != null)
                     extension = await GetTargetExtension(oldLocation, newLocation);
 
-                //Calculate optimal position avoiding overlaps with existing nodes
                 double nodePositionX = 0;
                 double nodePositionY = 0;
                 if (srcNode != null)
@@ -1549,14 +1543,14 @@ public partial class Overview : IAsyncDisposable
                     nodePositionY = newPosition.Y;
                 }
 
-                if (await AddSystemNode(MapId.Value, newLocation, accountID, extension, nodePositionX, nodePositionY))//add system node if system is not already added
+                if (await AddSystemNode(mapId, newLocation, accountID, extension, nodePositionX, nodePositionY))//add system node if system is not already added
                 {
                     targetNode = await GetNodeBySolarSystemId(newLocation.SolarSystemId);
 
 
                     if (srcNode != null && targetNode != null && !await IsLinkExist(srcNode, targetNode))
                     {
-                        if (!await AddSystemNodeLink(MapId.Value, srcNode, targetNode, accountID))//create if new target system added from src
+                        if (!await AddSystemNodeLink(mapId, srcNode, targetNode, accountID))//create if new target system added from src
                         {
                             Logger.LogError("Add Wormhole Link error");
                             Snackbar?.Add("Add Wormhole Link error", Severity.Error);
@@ -1566,10 +1560,9 @@ public partial class Overview : IAsyncDisposable
             }
             else// tartget system already added
             {
-                //check if link already exist, if not create if
                 if (srcNode != null && targetNode != null && !await IsLinkExist(srcNode, targetNode))
                 {
-                    if (!await AddSystemNodeLink(MapId.Value, srcNode, targetNode, accountID))//create if new target system added from src
+                    if (!await AddSystemNodeLink(mapId, srcNode, targetNode, accountID))//create if new target system added from src
                     {
                         Logger.LogError("Add Wormhole Link error");
                         Snackbar?.Add("Add Wormhole Link error", Severity.Error);
@@ -1590,11 +1583,9 @@ public partial class Overview : IAsyncDisposable
                 }
             }
 
-            //update user position
             CharacterEntity? user = await eveMapperService.GetCharacter(accountID);
             if (user != null)
             {
-                //remove user from old system if exist
                 EveSystemNodeModel? userSystem = (EveSystemNodeModel?)_blazorDiagram?.Nodes?.FirstOrDefault(x => ((EveSystemNodeModel)x)!.ConnectedUsers.Contains(user.Name));
                 if (userSystem != null)
                 {
@@ -1669,7 +1660,6 @@ public partial class Overview : IAsyncDisposable
                     return false;
                 }
 
-                // Set the destination waypoint using the EveServices
                 await EveServices.SetEveCharacterAuthenticatication(token);
                 await EveServices.UserInterfaceServices.SetWaypoint(solarSystemId, false, true);
                 return true;
@@ -1896,7 +1886,6 @@ public partial class Overview : IAsyncDisposable
                     link = await DbWHSystemLinks.Update(SelectedSystemLink.Id, link);
                     if (link != null)
                     {
-                        //update link size on diagram (refresh link
                         SelectedSystemLink.Size = link.Size;
                         SelectedSystemLink.Refresh();
                         WHMapperUser? primaryAccount = await GetPrimaryAccountAsync();

--- a/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Map/Overview.razor.cs
@@ -132,6 +132,26 @@ public partial class Overview : IAsyncDisposable
 
     private CancellationTokenSource _cts = new();
 
+    /// <summary>
+    /// Acquires the semaphore unless the component is being disposed.
+    /// Returns false when the wait was cancelled so callers can skip their work.
+    /// </summary>
+    private async Task<bool> TryAcquireSemaphoreAsync(SemaphoreSlim semaphore)
+    {
+        try
+        {
+            await semaphore.WaitAsync(_cts.Token);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
 
     private async Task<WHMapperUser[]?> GetAccountsAsync()
     {
@@ -187,7 +207,7 @@ public partial class Overview : IAsyncDisposable
             _cts = new CancellationTokenSource();
         }
 
-        _ = Task.Run(() => LoadMapAsync(_cts.Token));
+        _ = Task.Run(() => LoadMapAsync(_cts.Token), _cts.Token);
 
         Logger.LogInformation("OnParametersSetAsync completed with MapId: {MapId}", MapId);
 
@@ -651,7 +671,8 @@ public partial class Overview : IAsyncDisposable
     #region Diagram Selection
     private async Task OnDiagramSelectionChanged(Blazor.Diagrams.Core.Models.Base.SelectableModel? item)
     {
-        await _semaphoreSlim.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim))
+            return;
         try
         {
             await InvokeAsync(() =>
@@ -726,7 +747,8 @@ public partial class Overview : IAsyncDisposable
     #region Diagram Keyboard Events
     private async Task OnDiagramKeyDown(Blazor.Diagrams.Core.Events.KeyboardEventArgs eventArgs)
     {
-        await _semaphoreSlim.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim))
+            return;
         try
         {
             if (await HandleLinkSystemKey(eventArgs) ||
@@ -910,7 +932,8 @@ public partial class Overview : IAsyncDisposable
         if (item == null || item.GetType() != typeof(EveSystemNodeModel))
             return;
 
-        await _semaphoreSlim.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim))
+            return;
         try
         {
             var node = (EveSystemNodeModel)item;
@@ -976,7 +999,7 @@ public partial class Overview : IAsyncDisposable
                 {
                     await EveMapperRealTime.NotifyWormholeLockChanged(primaryAccount.Id, whNodeModel.IdWHMap, whNodeModel.IdWH, whNodeModel.Locked);
                 }
-            });
+            }, _cts.Token);
         }
     }
 
@@ -991,7 +1014,7 @@ public partial class Overview : IAsyncDisposable
                 {
                     await EveMapperRealTime.NotifyWormholeSystemStatusChanged(primaryAccount.Id, whNodeModel.IdWHMap, whNodeModel.IdWH, whNodeModel.SystemStatus);
                 }
-            });
+            }, _cts.Token);
         }
     }
 
@@ -1016,7 +1039,7 @@ public partial class Overview : IAsyncDisposable
                     {
                         await EveMapperRealTime.NotifyAlternameNameChanged(primaryAccount.Id, whNodeModel.IdWHMap, whNodeModel.IdWH, whNodeModel.AlternateName);
                     }
-                });
+                }, _cts.Token);
             }
         }
     }
@@ -1519,7 +1542,8 @@ public partial class Overview : IAsyncDisposable
         EveSystemNodeModel? srcNode = null;
         EveSystemNodeModel? targetNode = null;
 
-        await _semaphoreSlim.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim))
+            return;
         try
         {
             if (oldLocation != null)
@@ -1997,7 +2021,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnUserDisconnected(int accountID)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             CharacterEntity? user = await eveMapperService.GetCharacter(accountID);
@@ -2023,7 +2048,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnUserPositionChanged(int accountID, int mapId, int wormholeId)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             WHMapperUser[]? accounts = await GetAccountsAsync();
@@ -2060,7 +2086,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnWormholeAdded(int accountID, int mapId, int whId)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             WHMapperUser[]? accounts = await GetAccountsAsync();
@@ -2094,7 +2121,8 @@ public partial class Overview : IAsyncDisposable
     }
     private async Task OnWormholeRemoved(int accountID, int mapId, int whId)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             WHMapperUser[]? accounts = await GetAccountsAsync();
@@ -2125,7 +2153,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnWormholeMoved(int accountID, int mapId, int whId, double posX, double posY)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             WHMapperUser[]? accounts = await GetAccountsAsync();
@@ -2155,7 +2184,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnLinkAdded(int accountID, int mapId, int linkId)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             WHMapperUser[]? accounts = await GetAccountsAsync();
@@ -2195,7 +2225,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnLinkRemoved(int accountID, int mapId, int linkId)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             var accounts = await GetAccountsAsync();
@@ -2234,7 +2265,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnLinkChanged(int accountID, int mapId, int linkId, SystemLinkEolStatus eolStatus, SystemLinkSize size, SystemLinkMassStatus massStatus)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             var accounts = await GetAccountsAsync();
@@ -2269,7 +2301,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnWormholeLockChanged(int accountID, int mapId, int whId, bool locked)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             var accounts = await GetAccountsAsync();
@@ -2292,7 +2325,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnWormholeSystemStatusChanged(int accountID, int mapId, int whId, WHSystemStatus systemStatus)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             var accounts = await GetAccountsAsync();
@@ -2318,7 +2352,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnWormholeNameExtensionChanged(int accountID, int mapId, int whId, char? extension)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             var accounts = await GetAccountsAsync();
@@ -2344,7 +2379,8 @@ public partial class Overview : IAsyncDisposable
 
     private async Task OnWormholeAlternateNameChanged(int accountID, int mapId, int whId, string? name)
     {
-        await _semaphoreSlim2.WaitAsync();
+        if (!await TryAcquireSemaphoreAsync(_semaphoreSlim2))
+            return;
         try
         {
             var accounts = await GetAccountsAsync();

--- a/src/WHMapper/Components/Pages/Mapper/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Overview.razor.cs
@@ -93,7 +93,6 @@ public partial class Overview : IAsyncDisposable
             Snackbar?.Add("RealTimeService Initialization error", Severity.Error);
         }
 
-        // Subscribe to primary account changes to reload maps
         UserManagement.PrimaryAccountChanged += OnPrimaryAccountChanged;
 
         await base.OnInitializedAsync();
@@ -130,7 +129,7 @@ public partial class Overview : IAsyncDisposable
             WHMaps.Clear();
             
             // Load maps based on primary account's access, not the authenticated user
-            if (PrimaryAccount == null)
+            if (PrimaryAccount == null && !string.IsNullOrEmpty(UID.ClientId))
             {
                 PrimaryAccount = await UserManagement.GetPrimaryAccountAsync(UID.ClientId);
             }
@@ -145,7 +144,6 @@ public partial class Overview : IAsyncDisposable
     
             foreach (var map in allMaps)
             {
-                // Check if the primary account has access to this map
                 if (await AccessHelper.IsEveMapperMapAccessAuthorized(PrimaryAccount.Id, map.Id))
                 {
                     WHMaps.Add(map);
@@ -181,10 +179,8 @@ public partial class Overview : IAsyncDisposable
             _loading = true;
             await InvokeAsync(StateHasChanged);
             
-            // Update the primary account reference
             PrimaryAccount = await UserManagement.GetPrimaryAccountAsync(UID.ClientId);
             
-            // Reload maps for the new primary account
             if (!await RestoreMaps())
             {
                 Snackbar?.Add("Error reloading maps after primary account change", Severity.Error);
@@ -214,7 +210,6 @@ public partial class Overview : IAsyncDisposable
             return ValueTask.CompletedTask;
         _disposed = true;
         
-        // Unsubscribe from primary account changes
         UserManagement.PrimaryAccountChanged -= OnPrimaryAccountChanged;
         
         // Note: Do NOT dispose TrackerServices here - it's a scoped service managed by DI
@@ -290,7 +285,6 @@ public partial class Overview : IAsyncDisposable
         await _semaphoreSlim.WaitAsync();
         try
         {
-            //Check if map is already in the list
             if(WHMaps.Any(m=>m.Id==mapId))
             {
                 return;
@@ -299,7 +293,6 @@ public partial class Overview : IAsyncDisposable
             var map = await DbWHMaps.GetById(mapId);
             if (map != null && PrimaryAccount != null)
             {
-                // Check if the primary account has access to this map
                 if (await AccessHelper.IsEveMapperMapAccessAuthorized(PrimaryAccount.Id, map.Id))
                 {
                     WHMaps.Add(map);
@@ -410,7 +403,6 @@ public partial class Overview : IAsyncDisposable
                 return;
             }
             
-            // Check if the primary account has access to this map
             var hasAccess = await AccessHelper.IsEveMapperMapAccessAuthorized(PrimaryAccount.Id, mapWithAccessUpdated.Id);
             
 
@@ -467,14 +459,12 @@ public partial class Overview : IAsyncDisposable
                 {
                     map.WHMapAccesses.Remove(accessToRemove);
 
-                    // Check if the primary account still has access to this map
                     var hasAccess = await AccessHelper.IsEveMapperMapAccessAuthorized(PrimaryAccount.Id, map.Id);
                     if (!hasAccess)
                     {
                         var mapName = map.Name;
                         WHMaps.Remove(map);
                         
-                        // Reset selection if needed
                         if (_selectedWHMap?.Id == mapId)
                         {
                             _selectedWHMap = WHMaps.FirstOrDefault();
@@ -508,14 +498,12 @@ public partial class Overview : IAsyncDisposable
             {
                 map.WHMapAccesses.Clear();
                 
-                // Check if the primary account still has access to this map
                 var hasAccess = await AccessHelper.IsEveMapperMapAccessAuthorized(PrimaryAccount.Id, map.Id);
                 if (!hasAccess)
                 {
                     var mapName = map.Name;
                     WHMaps.Remove(map);
                     
-                    // Reset selection if needed
                     if (_selectedWHMap?.Id == mapId)
                     {
                         _selectedWHMap = WHMaps.FirstOrDefault();
@@ -569,7 +557,6 @@ public partial class Overview : IAsyncDisposable
                 return;
             }
 
-            // Reload maps as user may now have access to new maps
             var previousMapCount = WHMaps.Count;
             await RestoreMaps();
             
@@ -600,17 +587,13 @@ public partial class Overview : IAsyncDisposable
                 return;
             }
 
-            // Store current maps before reload
             var previousMaps = WHMaps.Select(m => m.Id).ToList();
             
-            // Reload maps as user may have lost access
             await RestoreMaps();
             
-            // Check if any maps were lost
             var lostMaps = previousMaps.Except(WHMaps.Select(m => m.Id)).ToList();
             if (lostMaps.Any())
             {
-                // Reset selection if needed
                 if (_selectedWHMap != null && lostMaps.Contains(_selectedWHMap.Id))
                 {
                     _selectedWHMap = WHMaps.FirstOrDefault();
@@ -642,7 +625,6 @@ public partial class Overview : IAsyncDisposable
                 return;
             }
 
-            // Store current maps before reload
             var previousMapCount = WHMaps.Count;
 
             // Reload maps - maps from the deleted instance will no longer exist
@@ -650,7 +632,6 @@ public partial class Overview : IAsyncDisposable
 
             if (WHMaps.Count < previousMapCount)
             {
-                // Reset selection if the current map was in the deleted instance
                 if (_selectedWHMap != null && !WHMaps.Any(m => m.Id == _selectedWHMap.Id))
                 {
                     _selectedWHMap = WHMaps.FirstOrDefault();
@@ -687,9 +668,8 @@ public partial class Overview : IAsyncDisposable
     #region Map Tab Events
         private Task CloseMapTab(MudTabPanel panel)
         {
-            if(panel!=null)
+            if(panel?.ID is int mapId)
             {
-                int mapId = (int)panel.ID;
                 var map = WHMaps.FirstOrDefault(m => m.Id == mapId);
                 if(map!=null)
                 {

--- a/src/WHMapper/Components/Pages/Mapper/Search/SearchSystem.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Search/SearchSystem.razor.cs
@@ -42,7 +42,7 @@ public partial class SearchSystem
 
     private async Task Submit()
     {
-        await _form.Validate();
+        await _form.ValidateAsync();
 
         if (_form.IsValid)
         {

--- a/src/WHMapper/Components/Pages/Mapper/Signatures/Import.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Signatures/Import.razor.cs
@@ -118,7 +118,7 @@ public partial class Import
 
     private async Task Submit()
     {
-        await _form.Validate();
+        await _form.ValidateAsync();
 
         if (_form.IsValid)
         {

--- a/src/WHMapper/Components/Pages/Mapper/Signatures/Overview.razor
+++ b/src/WHMapper/Components/Pages/Mapper/Signatures/Overview.razor
@@ -2,10 +2,10 @@
 @using WHMapper.Models.DTO.EveMapper.Enums
 
 <MudPaper hidden="@(CurrentSystemNodeId == null)" Outlined="true" Class="d-flex align-stretch">
-<MudTable @ref="_signatureTable" Outlined="true" Items="@Signatures" Breakpoint="Breakpoint.Xs" Height="325px"
+<MudTable T="WHMapper.Models.Db.WHSignature" @ref="_signatureTable" Outlined="true" Items="@Signatures" Breakpoint="Breakpoint.Xs" Height="325px"
         Dense=true Hover=false Bordered=true Striped=true AllowUnsorted=false SortLabel="Sort By"  Virtualize="true" 
         Loading="@(Signatures==null)" LoadingProgressColor="Color.Info"
-        CommitEditTooltip="Commit" ApplyButtonPosition="TableApplyButtonPosition.End" CanCancelEdit="true" IsEditRowSwitchingBlocked="false" SelectedItem="_selectedSignature"
+        CommitEditTooltip="Commit" ApplyButtonPosition="TableApplyButtonPosition.End" CanCancelEdit="true" IsEditRowSwitchingBlocked="false"
         RowEditPreview="BackupSignature" RowEditCancel="ResetSignatureToOriginalValues" RowEditCommit="SignatureHasBeenCommitted" 
         CancelEditIcon="@Icons.Material.Filled.Cancel" CommitEditIcon="@Icons.Material.Filled.Edit" FixedHeader="true" HorizontalScrollbar="false">
     <ColGroup>

--- a/src/WHMapper/Components/Pages/Mapper/Signatures/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Signatures/Overview.razor.cs
@@ -57,7 +57,6 @@ public partial class Overview : ComponentBase,IDisposable
     [Parameter]
     public int? CurrentPrimaryUserId { get; set; } = null!;
 
-    private WHSignature? _selectedSignature;
     private WHSignature _signatureBeforeEdit = null!;
 
     private bool _isEditingSignature = false;
@@ -66,7 +65,7 @@ public partial class Overview : ComponentBase,IDisposable
     private DateTime _currentDateTime;
     private bool _disposed = false;
 
-    private MudTable<WHSignature?> _signatureTable { get; set; } =null!;
+    private MudTable<WHSignature> _signatureTable { get; set; } =null!;
 
     private string? _currentUser = null!;
 

--- a/src/WHMapper/Components/Pages/Mapper/Signatures/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Signatures/Overview.razor.cs
@@ -182,7 +182,7 @@ public partial class Overview : ComponentBase,IDisposable
         if(attribute is null)
             return value.ToString();
 
-        DisplayAttribute displayAttribute = (DisplayAttribute)attribute!;    
+        DisplayAttribute displayAttribute = (DisplayAttribute)attribute;
 
         return displayAttribute.ShortName ?? displayAttribute.Name ?? value.ToString();
     }

--- a/src/WHMapper/Components/Pages/Mapper/Signatures/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Signatures/Overview.razor.cs
@@ -90,7 +90,7 @@ public partial class Overview : ComponentBase,IDisposable
                 _cts.Dispose();
                 _cts = new CancellationTokenSource();
             }
-            Task.WhenAll(Task.Run(() => Restore()), Task.Run(() => HandleTimerAsync(_cts.Token)), Task.Run(() => LoadCurrentUserNameAsync()));
+            Task.WhenAll(Task.Run(() => Restore(), _cts.Token), Task.Run(() => HandleTimerAsync(_cts.Token), _cts.Token), Task.Run(() => LoadCurrentUserNameAsync(), _cts.Token));
         }
 
         return base.OnParametersSetAsync();
@@ -309,7 +309,7 @@ public partial class Overview : ComponentBase,IDisposable
         ((WHSignature)element).Updated = DateTime.UtcNow;
         ((WHSignature)element).UpdatedBy = _currentUser;
 
-        Task.Run(() => UpdateSignature(element));
+        Task.Run(() => UpdateSignature(element), _cts.Token);
 
         _isEditingSignature = false;
         StateHasChanged();

--- a/src/WHMapper/Components/Pages/Mapper/Users/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Users/Overview.razor.cs
@@ -49,14 +49,10 @@ public partial class Overview : IAsyncDisposable
 
     protected override async Task OnInitializedAsync()
     {
-        // Subscribe to primary account changes
         EveMapperUserManagementService.PrimaryAccountChanged += OnPrimaryAccountChangedHandler;
-        // Subscribe to current map changes
         EveMapperUserManagementService.CurrentMapChanged += OnCurrentMapChangedHandler;
-        // Subscribe to navigation changes
         Navigation.LocationChanged += OnLocationChanged;
         
-        // Check initial location
         UpdateInstancesPageState(Navigation.Uri);
         
         await base.OnInitializedAsync();
@@ -88,7 +84,6 @@ public partial class Overview : IAsyncDisposable
 
         if (EveMapperUserManagementService != null && UID != null && !String.IsNullOrEmpty(UID.ClientId))
         {
-            // Update map access status for all accounts based on primary account's maps
             await EveMapperUserManagementService.UpdateAccountsMapAccessAsync(UID.ClientId);
             
             Accounts = await EveMapperUserManagementService.GetAccountsAsync(UID.ClientId);
@@ -153,7 +148,6 @@ public partial class Overview : IAsyncDisposable
         {
             Logger.LogInformation("Setting primary account to {AccountId}", accountId);
             
-            // Stop tracking for all accounts before switching primary
             foreach (var account in Accounts)
             {
                 if (account.Tracking)
@@ -163,7 +157,6 @@ public partial class Overview : IAsyncDisposable
                 }
             }
             
-            // Set the new primary account - this will trigger OnPrimaryAccountChangedHandler
             // which will reload maps and manage tracking based on map access
             await EveMapperUserManagementService.SetPrimaryAccountAsync(UID.ClientId, accountId.ToString());
             StateHasChanged();
@@ -179,10 +172,8 @@ public partial class Overview : IAsyncDisposable
 
         Logger.LogInformation("Primary account changed to {AccountId}, updating tracking status", newPrimaryAccountId);
         
-        // Reload accounts to get updated HasMapAccess status
         Accounts = await EveMapperUserManagementService.GetAccountsAsync(UID.ClientId);
         
-        // Manage tracking based on map access
         foreach (var account in Accounts)
         {
             if (account.IsPrimary)
@@ -214,7 +205,6 @@ public partial class Overview : IAsyncDisposable
         
         await InvokeAsync(StateHasChanged);
         
-        // Notify parent to reload maps
         if (OnPrimaryAccountChanged.HasDelegate)
         {
             await OnPrimaryAccountChanged.InvokeAsync(newPrimaryAccountId);
@@ -230,7 +220,6 @@ public partial class Overview : IAsyncDisposable
 
         Logger.LogInformation("Current map changed to {MapId}, updating tracking status based on map access", mapId);
         
-        // Reload accounts to get updated HasCurrentMapAccess status
         Accounts = await EveMapperUserManagementService.GetAccountsAsync(UID.ClientId);
         
         // Don't manage tracking if we're on instances page
@@ -240,7 +229,6 @@ public partial class Overview : IAsyncDisposable
             return;
         }
         
-        // Manage tracking based on current map access
         foreach (var account in Accounts)
         {
             if (account.HasCurrentMapAccess)
@@ -298,7 +286,6 @@ public partial class Overview : IAsyncDisposable
     {
         Logger.LogInformation("Navigating to instances page - pausing tracking for all accounts");
         
-        // Save current tracking state and stop all tracking
         _savedTrackingState.Clear();
         foreach (var account in Accounts)
         {
@@ -316,7 +303,6 @@ public partial class Overview : IAsyncDisposable
     {
         Logger.LogInformation("Returning from instances page - restoring tracking state");
         
-        // Restore tracking state from before navigating to instances
         foreach (var account in Accounts)
         {
             if (_savedTrackingState.TryGetValue(account.Id, out var wasTracking) && wasTracking)
@@ -340,19 +326,16 @@ public partial class Overview : IAsyncDisposable
             return;
         _disposed = true;
         
-        // Unsubscribe from events
         EveMapperUserManagementService.PrimaryAccountChanged -= OnPrimaryAccountChangedHandler;
         EveMapperUserManagementService.CurrentMapChanged -= OnCurrentMapChangedHandler;
         Navigation.LocationChanged -= OnLocationChanged;
         
-        // Cancel pending operations
         if (_cts != null && !_cts.IsCancellationRequested)
         {
             _cts.Cancel();
         }
         _cts?.Dispose();
 
-        // Stop services for all accounts
         foreach (var account in Accounts)
         {
             try

--- a/src/WHMapper/Components/Pages/Mapper/Users/Overview.razor.cs
+++ b/src/WHMapper/Components/Pages/Mapper/Users/Overview.razor.cs
@@ -67,7 +67,7 @@ public partial class Overview : IAsyncDisposable
             _cts = new CancellationTokenSource();
         }
 
-        _ = Task.Run(async () => await LoadAccountsAsync(_cts.Token));
+        _ = Task.Run(async () => await LoadAccountsAsync(_cts.Token), _cts.Token);
         Logger.LogInformation("User Overview component OnParametersSetAsync done");
 
         await base.OnParametersSetAsync();

--- a/src/WHMapper/Data/WHMapperContext.cs
+++ b/src/WHMapper/Data/WHMapperContext.cs
@@ -28,18 +28,15 @@ namespace WHMapper.Data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            // Instance configuration
             modelBuilder.Entity<WHInstance>().ToTable("Instances");
             modelBuilder.Entity<WHInstance>().HasIndex(x => new { x.OwnerEveEntityId, x.OwnerType }).IsUnique(true);
             modelBuilder.Entity<WHInstance>().HasMany(x => x.WHMaps).WithOne().HasForeignKey(x => x.WHInstanceId).OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<WHInstance>().HasMany(x => x.Administrators).WithOne().HasForeignKey(x => x.WHInstanceId).IsRequired().OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<WHInstance>().HasMany(x => x.InstanceAccesses).WithOne().HasForeignKey(x => x.WHInstanceId).IsRequired().OnDelete(DeleteBehavior.Cascade);
 
-            // Instance Admin configuration
             modelBuilder.Entity<WHInstanceAdmin>().ToTable("InstanceAdmins");
             modelBuilder.Entity<WHInstanceAdmin>().HasIndex(x => new { x.WHInstanceId, x.EveCharacterId }).IsUnique(true);
 
-            // Instance Access configuration
             modelBuilder.Entity<WHInstanceAccess>().ToTable("InstanceAccesses");
             modelBuilder.Entity<WHInstanceAccess>().HasIndex(x => new { x.WHInstanceId, x.EveEntityId, x.EveEntity }).IsUnique(true);
 
@@ -49,7 +46,6 @@ namespace WHMapper.Data
             modelBuilder.Entity<WHMap>().HasMany(x => x.WHSystemLinks).WithOne().HasForeignKey(x => x.WHMapId).IsRequired().OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<WHMap>().HasMany(x => x.WHMapAccesses).WithOne(x => x.WHMap).HasForeignKey(x => x.WHMapId).IsRequired().OnDelete(DeleteBehavior.Cascade);
 
-            // Map Access configuration
             modelBuilder.Entity<WHMapAccess>().ToTable("MapAccesses");
             modelBuilder.Entity<WHMapAccess>().HasIndex(x => new { x.WHMapId, x.EveEntityId, x.EveEntity }).IsUnique(true);
 

--- a/src/WHMapper/Extensions/AuthenticationExtensions.cs
+++ b/src/WHMapper/Extensions/AuthenticationExtensions.cs
@@ -92,7 +92,7 @@ public static class AuthenticationExtensions
             options.AccessDeniedPath = "/Forbidden/";
             options.ExpireTimeSpan = TimeSpan.FromDays(7);
         })
-        .AddEveOnlineJwtBearer();
+        .AddEveOnlineJwtBearer(evessoConf["ClientId"] ?? throw new InvalidOperationException("ClientId is not configured in EveSSO settings."));
 
         services.ConfigureEveCookieRefresh(CookieAuthenticationDefaults.AuthenticationScheme, EVEOnlineAuthenticationDefaults.AuthenticationScheme);
 

--- a/src/WHMapper/Hubs/ConnectionMapping.cs
+++ b/src/WHMapper/Hubs/ConnectionMapping.cs
@@ -46,6 +46,14 @@ public class ConnectionMapping<T> where T : notnull
         }
     }
 
+    public IEnumerable<T> GetKeys()
+    {
+        lock (_connections)
+        {
+            return _connections.Keys.ToList();
+        }
+    }
+
     public void Remove(T key, string connectionId)
     {
         lock (_connections)

--- a/src/WHMapper/Hubs/WHMapperNotificationHub.cs
+++ b/src/WHMapper/Hubs/WHMapperNotificationHub.cs
@@ -3,16 +3,25 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using WHMapper.Models.Db.Enums;
 using WHMapper.Services.EveJwkExtensions;
+using WHMapper.Services.EveMapper;
 using WHMapper.Services.Metrics;
 
 namespace WHMapper.Hubs;
 
 [Authorize(AuthenticationSchemes = EveOnlineJwkDefaults.AuthenticationScheme)]
-public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMapperNotificationHub>
+public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAccessHelper accessHelper) : Hub<IWHMapperNotificationHub>
 {
     private readonly static ConnectionMapping<int> _connections = new ConnectionMapping<int>();
     private readonly static ConcurrentDictionary<int, KeyValuePair<int,int>?> _connectedUserPosition = new ConcurrentDictionary<int, KeyValuePair<int,int>?>();
     private readonly static ConcurrentDictionary<int, ConnectionMapping<int>> _mapConnections = new ConcurrentDictionary<int, ConnectionMapping<int>>();
+
+    // Tracks, per SignalR connection, the set of map ids the connection has been authorized to join.
+    // Populated in JoinMap after a server-side access check and consulted by every map-scoped Send*
+    // method so a client cannot broadcast into (or receive from) a map group it was never granted.
+    private readonly static ConcurrentDictionary<string, ConcurrentDictionary<int, byte>> _authorizedMaps = new ConcurrentDictionary<string, ConcurrentDictionary<int, byte>>();
+
+    private bool IsConnectionAuthorizedForMap(int mapId)
+        => _authorizedMaps.TryGetValue(Context.ConnectionId, out var maps) && maps.ContainsKey(mapId);
 
 
     private string CurrentUser()
@@ -92,22 +101,42 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
             }
         }
 
+        _authorizedMaps.TryRemove(Context.ConnectionId, out _);
+
         await base.OnDisconnectedAsync(exception);
     }
 
     public async Task JoinMap(int mapId)
     {
+        int accountID = CurrentAccountId();
+        if (accountID == 0)
+            throw new HubException("Unauthorized.");
+
+        // Server-side access check: the authenticated character must be allowed on this map
+        // (instance-level + map-level access). Never trust the client-supplied mapId on its own.
+        if (!await accessHelper.IsEveMapperMapAccessAuthorized(accountID, mapId))
+            throw new HubException("Access to the requested map is not authorized.");
+
+        var maps = _authorizedMaps.GetOrAdd(Context.ConnectionId, _ => new ConcurrentDictionary<int, byte>());
+        maps[mapId] = 0;
+
         await Groups.AddToGroupAsync(Context.ConnectionId, $"map:{mapId}");
     }
 
     public async Task LeaveMap(int mapId)
     {
+        if (_authorizedMaps.TryGetValue(Context.ConnectionId, out var maps))
+            maps.TryRemove(mapId, out _);
+
         await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"map:{mapId}");
     }
 
     public async Task SendUserPosition(int mapId,int wormholeId)
     {
         int accountID = CurrentAccountId();
+        if (accountID == 0 || !IsConnectionAuthorizedForMap(mapId))
+            return;
+
         _connectedUserPosition.AddOrUpdate(
             accountID,
             new KeyValuePair<int, int>(mapId, wormholeId),
@@ -119,7 +148,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendWormholeAdded(int mapId, int wowrmholeId)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             meters.AddSystem();
             await Clients.OthersInGroup($"map:{mapId}").NotifyWormoleAdded(accountID, mapId, wowrmholeId);
@@ -130,7 +159,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendWormholeRemoved(int mapId, int wowrmholeId)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             meters.DeleteSystem();
             await Clients.OthersInGroup($"map:{mapId}").NotifyWormholeRemoved(accountID, mapId, wowrmholeId);
@@ -140,7 +169,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendLinkAdded(int mapId, int linkId)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             meters.AddLink();
             await Clients.OthersInGroup($"map:{mapId}").NotifyLinkAdded(accountID, mapId, linkId);
@@ -150,7 +179,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendLinkRemoved(int mapId, int linkId)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             meters.DeleteLink();
             await Clients.OthersInGroup($"map:{mapId}").NotifyLinkRemoved(accountID, mapId, linkId);
@@ -160,7 +189,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendWormholeMoved(int mapId, int wowrmholeId, double posX, double posY)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             await Clients.OthersInGroup($"map:{mapId}").NotifyWormoleMoved(accountID, mapId, wowrmholeId, posX, posY);
         }
@@ -170,7 +199,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendLinkChanged(int mapId, int linkId, int eolStatus, SystemLinkSize size, int mass)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             await Clients.OthersInGroup($"map:{mapId}").NotifyLinkChanged(accountID, mapId, linkId, eolStatus, size, mass);
         }
@@ -179,7 +208,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendWormholeNameExtensionChanged(int mapId, int wowrmholeId,char? extension)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             await Clients.OthersInGroup($"map:{mapId}").NotifyWormholeNameExtensionChanged(accountID, mapId, wowrmholeId,extension);
         }
@@ -189,7 +218,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendWormholeSignaturesChanged(int mapId, int wowrmholeId)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             await Clients.OthersInGroup($"map:{mapId}").NotifyWormholeSignaturesChanged(accountID, mapId, wowrmholeId);
         }
@@ -198,7 +227,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendWormholeLockChanged(int mapId, int wormholeId, bool locked)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             await Clients.OthersInGroup($"map:{mapId}").NotifyWormholeLockChanged(accountID, mapId, wormholeId, locked);
         }
@@ -207,7 +236,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendWormholeSystemStatusChanged(int mapId, int wormholeId, WHSystemStatus systemStatus)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             await Clients.OthersInGroup($"map:{mapId}").NotifyWormholeSystemStatusChanged(accountID, mapId, wormholeId, systemStatus);
         }
@@ -216,7 +245,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendWormholeAlternateNameChanged(int mapId, int wormholeId, string? alternateName)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             await Clients.OthersInGroup($"map:{mapId}").NotifyWormholeAlternateNameChanged(accountID, mapId, wormholeId, alternateName);
         }
@@ -295,7 +324,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendUserOnMapConnected(int mapId)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             var mapping = _mapConnections.GetOrAdd(mapId, _ => new ConnectionMapping<int>());
             mapping.AddAndGetCount(accountID, Context.ConnectionId);
@@ -306,7 +335,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters) : Hub<IWHMappe
     public async Task SendUserOnMapDisconnected(int mapId)
     {
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAuthorizedForMap(mapId))
         {
             if (_mapConnections.TryGetValue(mapId, out var mapping))
             {

--- a/src/WHMapper/Hubs/WHMapperNotificationHub.cs
+++ b/src/WHMapper/Hubs/WHMapperNotificationHub.cs
@@ -15,14 +15,37 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
     private readonly static ConcurrentDictionary<int, KeyValuePair<int,int>?> _connectedUserPosition = new ConcurrentDictionary<int, KeyValuePair<int,int>?>();
     private readonly static ConcurrentDictionary<int, ConnectionMapping<int>> _mapConnections = new ConcurrentDictionary<int, ConnectionMapping<int>>();
 
-    // Tracks, per SignalR connection, the set of map ids the connection has been authorized to join.
-    // Populated in JoinMap after a server-side access check and consulted by every map-scoped Send*
-    // method so a client cannot broadcast into (or receive from) a map group it was never granted.
+    // Per-connection grants, filled only after a server-side access check. Every scoped Send* method
+    // consults them, so a client can never broadcast into a group it was not granted.
     private readonly static ConcurrentDictionary<string, ConcurrentDictionary<int, byte>> _authorizedMaps = new ConcurrentDictionary<string, ConcurrentDictionary<int, byte>>();
+
+    // Value is 1 when the account was an instance admin at join time. Membership is captured while
+    // access still exists, which is what lets revocation and deletion events reach the users concerned.
+    private readonly static ConcurrentDictionary<string, ConcurrentDictionary<int, byte>> _authorizedInstances = new ConcurrentDictionary<string, ConcurrentDictionary<int, byte>>();
 
     private bool IsConnectionAuthorizedForMap(int mapId)
         => _authorizedMaps.TryGetValue(Context.ConnectionId, out var maps) && maps.ContainsKey(mapId);
 
+    private bool IsConnectionAuthorizedForInstance(int instanceId)
+        => _authorizedInstances.TryGetValue(Context.ConnectionId, out var instances) && instances.ContainsKey(instanceId);
+
+    private bool IsConnectionAdminForInstance(int instanceId)
+        => _authorizedInstances.TryGetValue(Context.ConnectionId, out var instances)
+            && instances.TryGetValue(instanceId, out var isAdmin) && isAdmin == 1;
+
+    /// <summary>
+    /// Guard for instance-scoped broadcasts: the caller must be authenticated, must have joined the
+    /// instance group through a server-side access check, and must still be an admin of it. Every
+    /// method using this guard corresponds to an admin-only action in the UI.
+    /// </summary>
+    private async Task<int> RequireInstanceAdminAsync(int instanceId)
+    {
+        int accountID = CurrentAccountId();
+        if (accountID == 0 || !IsConnectionAuthorizedForInstance(instanceId))
+            return 0;
+
+        return await accessHelper.IsInstanceAdminAuthorized(accountID, instanceId) ? accountID : 0;
+    }
 
     private string CurrentUser()
     {
@@ -38,14 +61,15 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
     {
         if (Context != null && !String.IsNullOrEmpty(Context.UserIdentifier))
         {
-            var accountID = Context.UserIdentifier.Split(":")[2];
-            if (int.TryParse(accountID, out int res))
+            // UserIdentifier is expected as "CHARACTER:EVE:<id>"; never index blindly into it.
+            var parts = Context.UserIdentifier.Split(":");
+            if (parts.Length >= 3 && int.TryParse(parts[2], out int res))
                 return res;
 
         }
         return 0;
     }
-     
+
 
     public override async Task OnConnectedAsync()
     {
@@ -66,6 +90,12 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
         }
 
         await base.OnConnectedAsync();
+
+        // Subscribe to accessible instances here so the client never has to send an instance id.
+        foreach (var instanceId in await accessHelper.GetAccessibleInstanceIdsAsync(accountID))
+        {
+            await JoinInstanceGroupAsync(instanceId);
+        }
 
         if (isFirstConnection)
         {
@@ -102,6 +132,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
         }
 
         _authorizedMaps.TryRemove(Context.ConnectionId, out _);
+        _authorizedInstances.TryRemove(Context.ConnectionId, out _);
 
         await base.OnDisconnectedAsync(exception);
     }
@@ -112,8 +143,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
         if (accountID == 0)
             throw new HubException("Unauthorized.");
 
-        // Server-side access check: the authenticated character must be allowed on this map
-        // (instance-level + map-level access). Never trust the client-supplied mapId on its own.
+        // Never trust the client-supplied mapId on its own.
         if (!await accessHelper.IsEveMapperMapAccessAuthorized(accountID, mapId))
             throw new HubException("Access to the requested map is not authorized.");
 
@@ -121,6 +151,46 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
         maps[mapId] = 0;
 
         await Groups.AddToGroupAsync(Context.ConnectionId, $"map:{mapId}");
+
+        // Map access implies instance access, so join the owning instance group too.
+        var instanceId = await accessHelper.GetMapInstanceIdAsync(mapId);
+        if (instanceId.HasValue)
+            await JoinInstanceGroupAsync(instanceId.Value);
+    }
+
+    /// <summary>
+    /// Explicitly subscribe to instance-scoped events. Used by clients that are not currently
+    /// viewing a map (instance list, home page) and would otherwise never join a group.
+    /// </summary>
+    public async Task JoinInstance(int instanceId)
+    {
+        int accountID = CurrentAccountId();
+        if (accountID == 0)
+            throw new HubException("Unauthorized.");
+
+        if (!await accessHelper.IsEveMapperInstanceAccessAuthorized(accountID, instanceId))
+            throw new HubException("Access to the requested instance is not authorized.");
+
+        await JoinInstanceGroupAsync(instanceId);
+    }
+
+    public async Task LeaveInstance(int instanceId)
+    {
+        if (_authorizedInstances.TryGetValue(Context.ConnectionId, out var instances))
+            instances.TryRemove(instanceId, out _);
+
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"instance:{instanceId}");
+    }
+
+    private async Task JoinInstanceGroupAsync(int instanceId)
+    {
+        int accountID = CurrentAccountId();
+        bool isAdmin = accountID != 0 && await accessHelper.IsInstanceAdminAuthorized(accountID, instanceId);
+
+        var instances = _authorizedInstances.GetOrAdd(Context.ConnectionId, _ => new ConcurrentDictionary<int, byte>());
+        instances[instanceId] = isAdmin ? (byte)1 : (byte)0;
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"instance:{instanceId}");
     }
 
     public async Task LeaveMap(int mapId)
@@ -251,73 +321,89 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
         }
     }
 
+    /// <summary>
+    /// Positions are restricted to the maps this connection has been authorized to join, and a
+    /// snapshot is returned rather than the live global dictionary.
+    /// </summary>
     public Task<IDictionary<int, KeyValuePair<int, int>?>> GetConnectedUsersPosition()
     {
-        return Task.FromResult<IDictionary<int, KeyValuePair<int, int>?>>(_connectedUserPosition);
+        IDictionary<int, KeyValuePair<int, int>?> visible = new Dictionary<int, KeyValuePair<int, int>?>();
+
+        if (CurrentAccountId() == 0)
+            return Task.FromResult(visible);
+
+        foreach (var entry in _connectedUserPosition)
+        {
+            // Only expose a character's position when the caller shares the map that character is on.
+            if (entry.Value.HasValue && IsConnectionAuthorizedForMap(entry.Value.Value.Key))
+                visible[entry.Key] = entry.Value;
+        }
+
+        return Task.FromResult(visible);
     }
 
-    public async Task SendMapAdded(int mapId)
+    public async Task SendMapAdded(int instanceId, int mapId)
     {
-        int accountID = CurrentAccountId();
+        int accountID = await RequireInstanceAdminAsync(instanceId);
         if(accountID != 0)
         {
             meters.CreateMap();
-            await Clients.All.NotifyMapAdded(accountID, mapId);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyMapAdded(accountID, mapId);
         }
     }
 
-    public async Task SendMapRemoved(int mapId)
+    public async Task SendMapRemoved(int instanceId, int mapId)
     {
-        int accountID = CurrentAccountId();
+        int accountID = await RequireInstanceAdminAsync(instanceId);
         if(accountID != 0)
         {
             meters.DeleteMap();
-            await Clients.All.NotifyMapRemoved(accountID, mapId);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyMapRemoved(accountID, mapId);
         }
     }
 
-    public async Task SendMapNameChanged(int mapId, string newName)
+    public async Task SendMapNameChanged(int instanceId, int mapId, string newName)
     {
-        int accountID = CurrentAccountId();
+        int accountID = await RequireInstanceAdminAsync(instanceId);
         if(accountID != 0)
         {
-            await Clients.All.NotifyMapNameChanged(accountID, mapId, newName);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyMapNameChanged(accountID, mapId, newName);
         }
     }
 
-    public async Task SendAllMapsRemoved()
+    public async Task SendAllMapsRemoved(int instanceId)
     {
-        int accountID = CurrentAccountId();
+        int accountID = await RequireInstanceAdminAsync(instanceId);
         if(accountID != 0)
         {
-            await Clients.All.NotifyAllMapsRemoved(accountID);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyAllMapsRemoved(accountID);
         }
     }
 
-    public async Task SendMapAccessesAdded(int mapId, IEnumerable<int> accessId)
+    public async Task SendMapAccessesAdded(int instanceId, int mapId, IEnumerable<int> accessId)
     {
-        int accountID = CurrentAccountId();
+        int accountID = await RequireInstanceAdminAsync(instanceId);
         if(accountID != 0)
         {
-            await Clients.All.NotifyMapAccessesAdded(accountID, mapId, accessId);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyMapAccessesAdded(accountID, mapId, accessId);
         }
     }
 
-    public async Task SendMapAccessRemoved(int mapId, int accessId)
+    public async Task SendMapAccessRemoved(int instanceId, int mapId, int accessId)
     {
-        int accountID = CurrentAccountId();
+        int accountID = await RequireInstanceAdminAsync(instanceId);
         if(accountID != 0)
         {
-            await Clients.All.NotifyMapAccessRemoved(accountID, mapId, accessId);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyMapAccessRemoved(accountID, mapId, accessId);
         }
     }
 
-    public async Task SendMapAllAccessesRemoved(int mapId)
+    public async Task SendMapAllAccessesRemoved(int instanceId, int mapId)
     {
-        int accountID = CurrentAccountId();
+        int accountID = await RequireInstanceAdminAsync(instanceId);
         if(accountID != 0)
         {
-            await Clients.All.NotifyMapAllAccessesRemoved(accountID, mapId);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyMapAllAccessesRemoved(accountID, mapId);
         }
     }
 
@@ -347,38 +433,59 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
 
     public Task<int> GetTotalConnectedUsers()
     {
-        return Task.FromResult(_connections.Count);
+        return Task.FromResult(CurrentAccountId() == 0 ? 0 : _connections.Count);
     }
 
     public Task<int> GetUserCountOnMap(int mapId)
     {
+        if (CurrentAccountId() == 0 || !IsConnectionAuthorizedForMap(mapId))
+            return Task.FromResult(0);
+
         return Task.FromResult(_mapConnections.TryGetValue(mapId, out var mapping) ? mapping.Count : 0);
     }
 
+    /// <summary>
+    /// An access grant has to reach a character that, by definition, was not yet a member of the
+    /// instance group. The audience is therefore resolved from the freshly persisted access rules
+    /// rather than from group membership.
+    /// </summary>
     public async Task SendInstanceAccessAdded(int instanceId, int accessId)
     {
-        int accountID = CurrentAccountId();
-        if(accountID != 0)
+        int accountID = await RequireInstanceAdminAsync(instanceId);
+        if(accountID == 0)
+            return;
+
+        var targets = new List<string>();
+        foreach (var connectedAccountId in _connections.GetKeys())
         {
-            await Clients.All.NotifyInstanceAccessAdded(accountID, instanceId, accessId);
+            if (connectedAccountId == accountID)
+                continue;
+
+            if (await accessHelper.IsEveMapperInstanceAccessAuthorized(connectedAccountId, instanceId))
+                targets.AddRange(_connections.GetConnections(connectedAccountId));
         }
+
+        if (targets.Count > 0)
+            await Clients.Clients(targets).NotifyInstanceAccessAdded(accountID, instanceId, accessId);
     }
 
     public async Task SendInstanceAccessRemoved(int instanceId, int accessId)
     {
-        int accountID = CurrentAccountId();
+        int accountID = await RequireInstanceAdminAsync(instanceId);
         if(accountID != 0)
         {
-            await Clients.All.NotifyInstanceAccessRemoved(accountID, instanceId, accessId);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyInstanceAccessRemoved(accountID, instanceId, accessId);
         }
     }
 
     public async Task SendInstanceRemoved(int instanceId)
     {
+        // The instance row is already gone by the time this is called, so admin rights cannot be
+        // re-queried; the status recorded when the connection joined the group is used instead.
         int accountID = CurrentAccountId();
-        if(accountID != 0)
+        if(accountID != 0 && IsConnectionAdminForInstance(instanceId))
         {
-            await Clients.All.NotifyInstanceRemoved(accountID, instanceId);
+            await Clients.OthersInGroup($"instance:{instanceId}").NotifyInstanceRemoved(accountID, instanceId);
         }
     }
 

--- a/src/WHMapper/Hubs/WHMapperNotificationHub.cs
+++ b/src/WHMapper/Hubs/WHMapperNotificationHub.cs
@@ -327,10 +327,10 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
     /// </summary>
     public Task<IDictionary<int, KeyValuePair<int, int>?>> GetConnectedUsersPosition()
     {
-        IDictionary<int, KeyValuePair<int, int>?> visible = new Dictionary<int, KeyValuePair<int, int>?>();
+        Dictionary<int, KeyValuePair<int, int>?> visible = new Dictionary<int, KeyValuePair<int, int>?>();
 
         if (CurrentAccountId() == 0)
-            return Task.FromResult(visible);
+            return Task.FromResult<IDictionary<int, KeyValuePair<int, int>?>>(visible);
 
         foreach (var entry in _connectedUserPosition)
         {
@@ -339,7 +339,7 @@ public class WHMapperNotificationHub(WHMapperStoreMetrics meters, IEveMapperAcce
                 visible[entry.Key] = entry.Value;
         }
 
-        return Task.FromResult(visible);
+        return Task.FromResult<IDictionary<int, KeyValuePair<int, int>?>>(visible);
     }
 
     public async Task SendMapAdded(int instanceId, int mapId)

--- a/src/WHMapper/Models/DTO/EveAPI/Character/Portrait.cs
+++ b/src/WHMapper/Models/DTO/EveAPI/Character/Portrait.cs
@@ -7,15 +7,15 @@ public class Portrait
 {
 
     [JsonPropertyName("px128x128")]
-    public string Picture128x128 { get; set; }
+    public string Picture128x128 { get; set; } = string.Empty;
 
     [JsonPropertyName("px256x256")]
-    public string Picture256x256 { get; set; }
+    public string Picture256x256 { get; set; } = string.Empty;
 
     [JsonPropertyName("px512x512")]
-    public string Picture512x512 { get; set; }
+    public string Picture512x512 { get; set; } = string.Empty;
 
     [JsonPropertyName("px64x64")]
-    public string Picture64x64 { get; set; }
+    public string Picture64x64 { get; set; } = string.Empty;
 
 }

--- a/src/WHMapper/Models/DTO/Result.cs
+++ b/src/WHMapper/Models/DTO/Result.cs
@@ -24,26 +24,14 @@ namespace WHMapper.Models.DTO
             RetryAfter = retryAfter;
         }
 
-        /// <summary>
-        /// Creates a successful result with data
-        /// </summary>
         public static Result<T> Success(T data) => new(true, data, null, null, null, null);
 
-        /// <summary>
-        /// Creates a failed result with error message and optional status code
-        /// </summary>
         public static Result<T> Failure(string errorMessage, int? statusCode = null, Exception? exception = null, TimeSpan? retryAfter = null) 
             => new(false, default, errorMessage, statusCode, exception, retryAfter);
 
-        /// <summary>
-        /// Creates a failed result from an exception
-        /// </summary>
         public static Result<T> Failure(Exception exception, int? statusCode = null, TimeSpan? retryAfter = null) 
             => new(false, default, exception.Message, statusCode, exception, retryAfter);
 
-        /// <summary>
-        /// Implicitly converts a successful value to a Result
-        /// </summary>
         public static implicit operator Result<T>(T value) => Success(value);
     }
 
@@ -67,20 +55,11 @@ namespace WHMapper.Models.DTO
             RetryAfter = retryAfter;
         }
 
-        /// <summary>
-        /// Creates a successful result
-        /// </summary>
         public static Result Success() => new(true, null, null, null, null);
         
-        /// <summary>
-        /// Creates a failed result with error message and optional status code
-        /// </summary>
         public static Result Failure(string errorMessage, int? statusCode = null, Exception? exception = null, TimeSpan? retryAfter = null) 
             => new(false, errorMessage, statusCode, exception, retryAfter);
 
-        /// <summary>
-        /// Creates a failed result from an exception
-        /// </summary>
         public static Result Failure(Exception exception, int? statusCode = null, TimeSpan? retryAfter = null) 
             => new(false, exception.Message, statusCode, exception, retryAfter);
     }

--- a/src/WHMapper/Models/Db/WHInstance.cs
+++ b/src/WHMapper/Models/Db/WHInstance.cs
@@ -12,16 +12,10 @@ namespace WHMapper.Models.Db
         [Key]
         public int Id { get; set; }
 
-        /// <summary>
-        /// Display name for the instance
-        /// </summary>
         [Required]
         [StringLength(255, ErrorMessage = "Instance name is too long.")]
         public string Name { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Description of the instance
-        /// </summary>
         [StringLength(1000, ErrorMessage = "Description is too long.")]
         public string? Description { get; set; }
 
@@ -31,53 +25,26 @@ namespace WHMapper.Models.Db
         [Required]
         public int OwnerEveEntityId { get; set; }
 
-        /// <summary>
-        /// The name of the owner entity
-        /// </summary>
         [Required]
         public string OwnerEveEntityName { get; set; } = string.Empty;
 
-        /// <summary>
-        /// The type of entity that owns this instance
-        /// </summary>
         [Required]
         public WHAccessEntity OwnerType { get; set; }
 
-        /// <summary>
-        /// The character ID of the user who created the instance
-        /// </summary>
         [Required]
         public int CreatorCharacterId { get; set; }
 
-        /// <summary>
-        /// The character name of the user who created the instance
-        /// </summary>
         [Required]
         public string CreatorCharacterName { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Date when the instance was created
-        /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-        /// <summary>
-        /// Whether the instance is active
-        /// </summary>
         public bool IsActive { get; set; } = true;
 
-        /// <summary>
-        /// Maps belonging to this instance
-        /// </summary>
         public virtual ICollection<WHMap> WHMaps { get; } = new HashSet<WHMap>();
 
-        /// <summary>
-        /// Administrators of this instance
-        /// </summary>
         public virtual ICollection<WHInstanceAdmin> Administrators { get; } = new HashSet<WHInstanceAdmin>();
 
-        /// <summary>
-        /// Access entries for this instance (who can access the instance)
-        /// </summary>
         public virtual ICollection<WHInstanceAccess> InstanceAccesses { get; } = new HashSet<WHInstanceAccess>();
 
         [Obsolete("EF Requires it")]
@@ -94,7 +61,6 @@ namespace WHMapper.Models.Db
             CreatorCharacterName = creatorCharacterName;
         }
 
-        //add constructor with description
         public WHInstance(string name, int ownerEveEntityId, string ownerEveEntityName, WHAccessEntity ownerType,
             int creatorCharacterId, string creatorCharacterName, string? description)
             : this(name, ownerEveEntityId, ownerEveEntityName, ownerType, creatorCharacterId, creatorCharacterName)

--- a/src/WHMapper/Models/Db/WHInstanceAccess.cs
+++ b/src/WHMapper/Models/Db/WHInstanceAccess.cs
@@ -12,9 +12,6 @@ namespace WHMapper.Models.Db
         [Key]
         public int Id { get; set; }
 
-        /// <summary>
-        /// The instance this access belongs to
-        /// </summary>
         [Required]
         public int WHInstanceId { get; set; }
 
@@ -24,21 +21,12 @@ namespace WHMapper.Models.Db
         [Required]
         public int EveEntityId { get; set; }
 
-        /// <summary>
-        /// The name of the EVE entity
-        /// </summary>
         [Required]
         public string EveEntityName { get; set; } = string.Empty;
 
-        /// <summary>
-        /// The type of EVE entity
-        /// </summary>
         [Required]
         public WHAccessEntity EveEntity { get; set; }
 
-        /// <summary>
-        /// Date when the access was granted
-        /// </summary>
         public DateTime GrantedAt { get; set; } = DateTime.UtcNow;
 
         [Obsolete("EF Requires it")]

--- a/src/WHMapper/Models/Db/WHInstanceAdmin.cs
+++ b/src/WHMapper/Models/Db/WHInstanceAdmin.cs
@@ -11,21 +11,12 @@ namespace WHMapper.Models.Db
         [Key]
         public int Id { get; set; }
 
-        /// <summary>
-        /// The instance this admin belongs to
-        /// </summary>
         [Required]
         public int WHInstanceId { get; set; }
 
-        /// <summary>
-        /// The EVE character ID of the admin
-        /// </summary>
         [Required]
         public int EveCharacterId { get; set; }
 
-        /// <summary>
-        /// The EVE character name of the admin
-        /// </summary>
         [Required]
         public string EveCharacterName { get; set; } = string.Empty;
 
@@ -34,9 +25,6 @@ namespace WHMapper.Models.Db
         /// </summary>
         public bool IsOwner { get; set; } = false;
 
-        /// <summary>
-        /// Date when the admin was added
-        /// </summary>
         public DateTime AddedAt { get; set; } = DateTime.UtcNow;
 
         [Obsolete("EF Requires it")]

--- a/src/WHMapper/Models/Db/WHMapAccess.cs
+++ b/src/WHMapper/Models/Db/WHMapAccess.cs
@@ -13,9 +13,6 @@ namespace WHMapper.Models.Db
         [Key]
         public int Id { get; set; }
 
-        /// <summary>
-        /// The map this access belongs to
-        /// </summary>
         [Required]
         public int WHMapId { get; set; }
 
@@ -25,27 +22,15 @@ namespace WHMapper.Models.Db
         [Required]
         public int EveEntityId { get; set; }
 
-        /// <summary>
-        /// The name of the EVE entity
-        /// </summary>
         [Required]
         [StringLength(255)]
         public string EveEntityName { get; set; } = string.Empty;
 
-        /// <summary>
-        /// The type of EVE entity
-        /// </summary>
         [Required]
         public WHAccessEntity EveEntity { get; set; }
 
-        /// <summary>
-        /// Date when the access was granted
-        /// </summary>
         public DateTime GrantedAt { get; set; } = DateTime.UtcNow;
 
-        /// <summary>
-        /// Navigation property to the map
-        /// </summary>
         public virtual WHMap? WHMap { get; set; }
 
         [Obsolete("EF Requires it")]

--- a/src/WHMapper/Models/Db/WHUserSetting.cs
+++ b/src/WHMapper/Models/Db/WHUserSetting.cs
@@ -4,7 +4,6 @@ namespace WHMapper.Models.Db
 {
     public class WHUserSetting
     {
-        // Default constants
         public const string DEFAULT_KEY_LINK = "KeyL";
         public const string DEFAULT_KEY_DELETE = "Delete";
         public const string DEFAULT_KEY_INCREMENT_EXTENSION = "NumpadAdd";

--- a/src/WHMapper/Repositories/WHInstances/IWHInstanceRepository.cs
+++ b/src/WHMapper/Repositories/WHInstances/IWHInstanceRepository.cs
@@ -44,9 +44,6 @@ namespace WHMapper.Repositories.WHInstances
         /// </summary>
         Task<bool> IsInstanceAdminAsync(int instanceId, int characterId);
 
-        /// <summary>
-        /// Gets all access entries for an instance
-        /// </summary>
         Task<IEnumerable<WHInstanceAccess>?> GetInstanceAccessesAsync(int instanceId);
 
         /// <summary>

--- a/src/WHMapper/Repositories/WHInstances/WHInstanceRepository.cs
+++ b/src/WHMapper/Repositories/WHInstances/WHInstanceRepository.cs
@@ -265,14 +265,12 @@ namespace WHMapper.Repositories.WHInstances
         {
             using var context = await _contextFactory.CreateDbContextAsync();
             
-            // Check if user is an admin
             var isAdmin = await context.DbWHInstanceAdmins
                 .AnyAsync(x => x.WHInstanceId == instanceId && x.EveCharacterId == characterId);
             
             if (isAdmin)
                 return true;
 
-            // Check access entries
             return await context.DbWHInstanceAccesses
                 .AnyAsync(x => x.WHInstanceId == instanceId && (
                     (x.EveEntityId == characterId && x.EveEntity == WHAccessEntity.Character) ||

--- a/src/WHMapper/Repositories/WHMapAccesses/IWHMapAccessRepository.cs
+++ b/src/WHMapper/Repositories/WHMapAccesses/IWHMapAccessRepository.cs
@@ -4,9 +4,6 @@ namespace WHMapper.Repositories.WHMapAccesses
 {
     public interface IWHMapAccessRepository : IDefaultRepository<WHMapAccess, int>
     {
-        /// <summary>
-        /// Gets all access entries for a specific map
-        /// </summary>
         Task<IEnumerable<WHMapAccess>?> GetMapAccessesAsync(int mapId);
 
         /// <summary>
@@ -34,9 +31,6 @@ namespace WHMapper.Repositories.WHMapAccesses
         /// </summary>
         Task<bool> ClearMapAccessesAsync(int mapId);
 
-        /// <summary>
-        /// Gets the count of access entries for a map
-        /// </summary>
         Task<int> GetMapAccessCountAsync(int mapId);
 
         /// <summary>

--- a/src/WHMapper/Repositories/WHMapAccesses/WHMapAccessRepository.cs
+++ b/src/WHMapper/Repositories/WHMapAccesses/WHMapAccessRepository.cs
@@ -112,7 +112,6 @@ namespace WHMapper.Repositories.WHMapAccesses
             if (!hasRestrictions)
                 return true;
 
-            // Check if the entity has explicit access
             return await context.DbWHMapAccesses.AnyAsync(x =>
                 x.WHMapId == mapId && (
                     (x.EveEntityId == characterId && x.EveEntity == WHAccessEntity.Character) ||
@@ -181,20 +180,17 @@ namespace WHMapper.Repositories.WHMapAccesses
             
             try
             {
-                // Get all maps for this instance
                 var mapIds = await context.DbWHMaps
                     .Where(m => m.WHInstanceId == instanceId)
                     .Select(m => m.Id)
                     .ToListAsync();
 
-                // Find all map accesses for this entity in these maps
                 var accessesToRemove = await context.DbWHMapAccesses
                     .Where(a => mapIds.Contains(a.WHMapId) && a.EveEntityId == eveEntityId && a.EveEntity == eveEntity)
                     .ToListAsync();
 
                 if (accessesToRemove.Any())
                 {
-                    // Group by map ID for the result
                     result = accessesToRemove
                         .GroupBy(a => a.WHMapId)
                         .ToDictionary(g => g.Key, g => g.Select(a => a.Id).AsEnumerable());

--- a/src/WHMapper/Services/EveJwTExtensions/EveOnlineJwtBearerExtensions.cs
+++ b/src/WHMapper/Services/EveJwTExtensions/EveOnlineJwtBearerExtensions.cs
@@ -7,8 +7,11 @@ namespace WHMapper.Services.EveJwkExtensions
 {
     public static class EveOnlineJwtBearerExtensions
     {
-        public static AuthenticationBuilder AddEveOnlineJwtBearer([NotNull] this AuthenticationBuilder builder)
+        public static AuthenticationBuilder AddEveOnlineJwtBearer([NotNull] this AuthenticationBuilder builder, string applicationClientId)
         {
+            if (string.IsNullOrWhiteSpace(applicationClientId))
+                throw new InvalidOperationException("EveSSO ClientId is required to validate hub access tokens.");
+
             HttpClient httpClient = new HttpClient();
             httpClient.BaseAddress = new Uri(EveOnlineJwkDefaults.SSOUrl);
             httpClient.DefaultRequestHeaders.Host = EveOnlineJwkDefaults.EVE_HOST;
@@ -24,6 +27,7 @@ namespace WHMapper.Services.EveJwkExtensions
                 ValidateIssuer = true,
                 ValidIssuer = EveOnlineJwkDefaults.ValideIssuer,
                 ValidateIssuerSigningKey = true,
+                RequireExpirationTime = true,
 
                 IssuerSigningKey = jwk,
                 ClockSkew = TimeSpan.FromSeconds(2), // CCP's servers seem slightly ahead (~1s)
@@ -38,6 +42,15 @@ namespace WHMapper.Services.EveJwkExtensions
                 {
                     OnTokenValidated = context =>
                     {
+                        // ValidAudience is "EVE Online", present in every CCP token, so it would
+                        // also accept tokens minted for any other EVE application. "azp" is the
+                        // client id the token was actually issued to.
+                        var authorizedParty = context.Principal?.FindFirst("azp")?.Value;
+                        if (!string.Equals(authorizedParty, applicationClientId, StringComparison.Ordinal))
+                        {
+                            context.Fail("Token was not issued to this application.");
+                        }
+
                         return Task.CompletedTask;
                     },
                     OnAuthenticationFailed = context =>

--- a/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperAccessHandler.cs
+++ b/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperAccessHandler.cs
@@ -25,28 +25,36 @@ namespace WHMapper.Services.EveMapper.AuthorizationPolicies
         {
             var characterId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
 
-            if (string.IsNullOrEmpty(characterId))
+            if (string.IsNullOrEmpty(characterId) || !int.TryParse(characterId, out int authenticatedCharacterId))
                 return;
 
-            // Try to get the primary account from the user management service
-            // This handles multi-account scenarios where the user selects which account to use
+            // Multi-account handling: a single browser (client_uid) may group several authenticated
+            // EVE characters and act on behalf of a selected "primary" account.
+            // The client_uid cookie is client-supplied and must NOT be trusted on its own: only honor
+            // the primary-account decision once the authenticated identity is proven to belong to that
+            // group. Otherwise a fixed/guessed client_uid pointing at a privileged primary account would
+            // let any authenticated character inherit its access.
             var clientId = await _browserClientIdProvider.GetClientIdAsync();
-            if (!string.IsNullOrEmpty(clientId))
+            if (!string.IsNullOrWhiteSpace(clientId))
             {
-                var primaryAccount = await _userManagementService.GetPrimaryAccountAsync(clientId);
-                if (primaryAccount != null)
+                var accounts = await _userManagementService.GetAccountsAsync(clientId);
+                if (accounts.Any(a => a.Id == authenticatedCharacterId))
                 {
-                    // Check access for the primary account only
-                    if (await _eveMapperAccessHelper.IsEveMapperUserAccessAuthorized(primaryAccount.Id))
+                    var primaryAccount = await _userManagementService.GetPrimaryAccountAsync(clientId);
+                    if (primaryAccount != null)
                     {
-                        context.Succeed(requirement);
+                        // Check access for the primary account only
+                        if (await _eveMapperAccessHelper.IsEveMapperUserAccessAuthorized(primaryAccount.Id))
+                        {
+                            context.Succeed(requirement);
+                        }
+                        return;
                     }
-                    return;
                 }
             }
 
-            // Fallback: if no primary account is set, check the authenticated character
-            if (await _eveMapperAccessHelper.IsEveMapperUserAccessAuthorized(Convert.ToInt32(characterId)))
+            // Fallback: check the authenticated character directly
+            if (await _eveMapperAccessHelper.IsEveMapperUserAccessAuthorized(authenticatedCharacterId))
             {
                 context.Succeed(requirement);
             }

--- a/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperAccessHandler.cs
+++ b/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperAccessHandler.cs
@@ -1,65 +1,21 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using System.Security.Claims;
 using WHMapper.Services.BrowserClientIdProvider;
 
 namespace WHMapper.Services.EveMapper.AuthorizationPolicies
 {
-    public class EveMapperAccessHandler : AuthorizationHandler<EveMapperAccessRequirement>
+    public class EveMapperAccessHandler : EveMapperRequirementHandlerBase<EveMapperAccessRequirement>
     {
-
         private readonly IEveMapperAccessHelper _eveMapperAccessHelper;
-        private readonly IEveMapperUserManagementService _userManagementService;
-        private readonly IBrowserClientIdProvider _browserClientIdProvider;
 
         public EveMapperAccessHandler(
             IEveMapperAccessHelper eveMapperAccessHelper,
             IEveMapperUserManagementService userManagementService,
             IBrowserClientIdProvider browserClientIdProvider)
+            : base(userManagementService, browserClientIdProvider)
         {
             _eveMapperAccessHelper = eveMapperAccessHelper;
-            _userManagementService = userManagementService;
-            _browserClientIdProvider = browserClientIdProvider;
         }
 
-        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, EveMapperAccessRequirement requirement)
-        {
-            var characterId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
-
-            if (string.IsNullOrEmpty(characterId) || !int.TryParse(characterId, out int authenticatedCharacterId))
-                return;
-
-            // Multi-account handling: a single browser (client_uid) may group several authenticated
-            // EVE characters and act on behalf of a selected "primary" account.
-            // The client_uid cookie is client-supplied and must NOT be trusted on its own: only honor
-            // the primary-account decision once the authenticated identity is proven to belong to that
-            // group. Otherwise a fixed/guessed client_uid pointing at a privileged primary account would
-            // let any authenticated character inherit its access.
-            var clientId = await _browserClientIdProvider.GetClientIdAsync();
-            if (!string.IsNullOrWhiteSpace(clientId))
-            {
-                var accounts = await _userManagementService.GetAccountsAsync(clientId);
-                if (accounts.Any(a => a.Id == authenticatedCharacterId))
-                {
-                    var primaryAccount = await _userManagementService.GetPrimaryAccountAsync(clientId);
-                    if (primaryAccount != null)
-                    {
-                        // Check access for the primary account only
-                        if (await _eveMapperAccessHelper.IsEveMapperUserAccessAuthorized(primaryAccount.Id))
-                        {
-                            context.Succeed(requirement);
-                        }
-                        return;
-                    }
-                }
-            }
-
-            // Fallback: check the authenticated character directly
-            if (await _eveMapperAccessHelper.IsEveMapperUserAccessAuthorized(authenticatedCharacterId))
-            {
-                context.Succeed(requirement);
-            }
-
-            return;
-        }
+        protected override Task<bool> IsAuthorizedAsync(int eveCharacterId)
+            => _eveMapperAccessHelper.IsEveMapperUserAccessAuthorized(eveCharacterId);
     }
 }

--- a/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperAdminHandler.cs
+++ b/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperAdminHandler.cs
@@ -23,28 +23,36 @@ namespace WHMapper.Services.EveMapper.AuthorizationPolicies
         {
             var characterId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
 
-            if (string.IsNullOrEmpty(characterId))
+            if (string.IsNullOrEmpty(characterId) || !int.TryParse(characterId, out int authenticatedCharacterId))
                 return;
 
-            // Try to get the primary account from the user management service
-            // This handles multi-account scenarios where the user selects which account to use
+            // Multi-account handling: a single browser (client_uid) may group several authenticated
+            // EVE characters and act on behalf of a selected "primary" account.
+            // The client_uid cookie is client-supplied and must NOT be trusted on its own: only honor
+            // the primary-account decision once the authenticated identity is proven to belong to that
+            // group. Otherwise a fixed/guessed client_uid pointing at an admin primary account would
+            // let any authenticated character inherit admin rights.
             var clientId = await _browserClientIdProvider.GetClientIdAsync();
-            if (!string.IsNullOrEmpty(clientId))
+            if (!string.IsNullOrWhiteSpace(clientId))
             {
-                var primaryAccount = await _userManagementService.GetPrimaryAccountAsync(clientId);
-                if (primaryAccount != null)
+                var accounts = await _userManagementService.GetAccountsAsync(clientId);
+                if (accounts.Any(a => a.Id == authenticatedCharacterId))
                 {
-                    // Check access for the primary account only
-                    if (await _eveMapperAccessHelper.IsEveMapperAdminAccessAuthorized(primaryAccount.Id))
+                    var primaryAccount = await _userManagementService.GetPrimaryAccountAsync(clientId);
+                    if (primaryAccount != null)
                     {
-                        context.Succeed(requirement);
+                        // Check access for the primary account only
+                        if (await _eveMapperAccessHelper.IsEveMapperAdminAccessAuthorized(primaryAccount.Id))
+                        {
+                            context.Succeed(requirement);
+                        }
+                        return;
                     }
-                    return;
                 }
             }
 
-            // Fallback: if no primary account is set, check the authenticated character
-            if (await _eveMapperAccessHelper.IsEveMapperAdminAccessAuthorized(Convert.ToInt32(characterId)))
+            // Fallback: check the authenticated character directly
+            if (await _eveMapperAccessHelper.IsEveMapperAdminAccessAuthorized(authenticatedCharacterId))
             {
                 context.Succeed(requirement);
             }

--- a/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperAdminHandler.cs
+++ b/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperAdminHandler.cs
@@ -1,63 +1,21 @@
-﻿using Microsoft.AspNetCore.Authorization;
-using System.Security.Claims;
 using WHMapper.Services.BrowserClientIdProvider;
 
 namespace WHMapper.Services.EveMapper.AuthorizationPolicies
 {
-    public class EveMapperAdminHandler : AuthorizationHandler<EveMapperAdminRequirement>
+    public class EveMapperAdminHandler : EveMapperRequirementHandlerBase<EveMapperAdminRequirement>
     {
         private readonly IEveMapperAccessHelper _eveMapperAccessHelper;
-        private readonly IEveMapperUserManagementService _userManagementService;
-        private readonly IBrowserClientIdProvider _browserClientIdProvider;
 
-        public EveMapperAdminHandler(IEveMapperAccessHelper eveMapperAccessHelper,            
-        IEveMapperUserManagementService userManagementService,
+        public EveMapperAdminHandler(
+            IEveMapperAccessHelper eveMapperAccessHelper,
+            IEveMapperUserManagementService userManagementService,
             IBrowserClientIdProvider browserClientIdProvider)
+            : base(userManagementService, browserClientIdProvider)
         {
             _eveMapperAccessHelper = eveMapperAccessHelper;
-            _userManagementService = userManagementService;
-            _browserClientIdProvider = browserClientIdProvider;
         }
 
-        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, EveMapperAdminRequirement requirement)
-        {
-            var characterId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
-
-            if (string.IsNullOrEmpty(characterId) || !int.TryParse(characterId, out int authenticatedCharacterId))
-                return;
-
-            // Multi-account handling: a single browser (client_uid) may group several authenticated
-            // EVE characters and act on behalf of a selected "primary" account.
-            // The client_uid cookie is client-supplied and must NOT be trusted on its own: only honor
-            // the primary-account decision once the authenticated identity is proven to belong to that
-            // group. Otherwise a fixed/guessed client_uid pointing at an admin primary account would
-            // let any authenticated character inherit admin rights.
-            var clientId = await _browserClientIdProvider.GetClientIdAsync();
-            if (!string.IsNullOrWhiteSpace(clientId))
-            {
-                var accounts = await _userManagementService.GetAccountsAsync(clientId);
-                if (accounts.Any(a => a.Id == authenticatedCharacterId))
-                {
-                    var primaryAccount = await _userManagementService.GetPrimaryAccountAsync(clientId);
-                    if (primaryAccount != null)
-                    {
-                        // Check access for the primary account only
-                        if (await _eveMapperAccessHelper.IsEveMapperAdminAccessAuthorized(primaryAccount.Id))
-                        {
-                            context.Succeed(requirement);
-                        }
-                        return;
-                    }
-                }
-            }
-
-            // Fallback: check the authenticated character directly
-            if (await _eveMapperAccessHelper.IsEveMapperAdminAccessAuthorized(authenticatedCharacterId))
-            {
-                context.Succeed(requirement);
-            }
-
-            return;
-        }
+        protected override Task<bool> IsAuthorizedAsync(int eveCharacterId)
+            => _eveMapperAccessHelper.IsEveMapperAdminAccessAuthorized(eveCharacterId);
     }
 }

--- a/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperRequirementHandlerBase.cs
+++ b/src/WHMapper/Services/EveMapper/AuthorizationPolicies/EveMapperRequirementHandlerBase.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Authorization;
+using System.Security.Claims;
+using WHMapper.Services.BrowserClientIdProvider;
+
+namespace WHMapper.Services.EveMapper.AuthorizationPolicies
+{
+    public abstract class EveMapperRequirementHandlerBase<TRequirement>
+        : AuthorizationHandler<TRequirement>
+        where TRequirement : IAuthorizationRequirement
+    {
+        private readonly IEveMapperUserManagementService _userManagementService;
+        private readonly IBrowserClientIdProvider _browserClientIdProvider;
+
+        protected EveMapperRequirementHandlerBase(
+            IEveMapperUserManagementService userManagementService,
+            IBrowserClientIdProvider browserClientIdProvider)
+        {
+            _userManagementService = userManagementService;
+            _browserClientIdProvider = browserClientIdProvider;
+        }
+
+        // Implemented by each handler to call the matching access-helper method.
+        protected abstract Task<bool> IsAuthorizedAsync(int eveCharacterId);
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext context, TRequirement requirement)
+        {
+            var characterId = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? string.Empty;
+
+            if (string.IsNullOrEmpty(characterId) || !int.TryParse(characterId, out int authenticatedCharacterId))
+                return;
+
+            // Multi-account handling: a single browser (client_uid) may group several authenticated
+            // EVE characters and act on behalf of a selected "primary" account.
+            // The client_uid cookie is client-supplied and must NOT be trusted on its own: only honor
+            // the primary-account decision once the authenticated identity is proven to belong to that
+            // group. Otherwise a fixed/guessed client_uid pointing at a privileged primary account would
+            // let any authenticated character inherit its access.
+            var clientId = await _browserClientIdProvider.GetClientIdAsync();
+            if (!string.IsNullOrWhiteSpace(clientId))
+            {
+                var accounts = await _userManagementService.GetAccountsAsync(clientId);
+                if (accounts.Any(a => a.Id == authenticatedCharacterId))
+                {
+                    var primaryAccount = await _userManagementService.GetPrimaryAccountAsync(clientId);
+                    if (primaryAccount != null)
+                    {
+                        // Check access for the primary account only
+                        if (await IsAuthorizedAsync(primaryAccount.Id))
+                        {
+                            context.Succeed(requirement);
+                        }
+                        return;
+                    }
+                }
+            }
+
+            // Fallback: check the authenticated character directly
+            if (await IsAuthorizedAsync(authenticatedCharacterId))
+            {
+                context.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/src/WHMapper/Services/EveMapper/EveMapperAccessHelper.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperAccessHelper.cs
@@ -112,11 +112,57 @@ namespace WHMapper.Services.EveMapper
         }
 
         /// <summary>
+        /// Check if a user has access to a specific instance, without considering map-level restrictions.
+        /// </summary>
+        public async Task<bool> IsEveMapperInstanceAccessAuthorized(int eveCharacterId, int instanceId)
+        {
+            var characterResult = await _characterServices.GetCharacter(eveCharacterId);
+            if (!characterResult.IsSuccess || characterResult.Data == null)
+                return false;
+
+            var character = characterResult.Data;
+
+            return await _instanceRepo.HasInstanceAccessAsync(
+                instanceId,
+                eveCharacterId,
+                character.CorporationId > 0 ? character.CorporationId : null,
+                character.AllianceId > 0 ? character.AllianceId : null);
+        }
+
+        /// <summary>
+        /// Ids of every instance the character can access, through character, corporation or alliance.
+        /// </summary>
+        public async Task<IEnumerable<int>> GetAccessibleInstanceIdsAsync(int eveCharacterId)
+        {
+            var characterResult = await _characterServices.GetCharacter(eveCharacterId);
+            if (!characterResult.IsSuccess || characterResult.Data == null)
+                return Enumerable.Empty<int>();
+
+            var character = characterResult.Data;
+
+            var instances = await _instanceRepo.GetAccessibleInstancesAsync(
+                eveCharacterId,
+                character.CorporationId > 0 ? character.CorporationId : null,
+                character.AllianceId > 0 ? character.AllianceId : null);
+
+            return instances?.Select(i => i.Id).ToArray() ?? Enumerable.Empty<int>();
+        }
+
+        /// <summary>
         /// Checks if a character is an admin of a specific instance
         /// </summary>
         public async Task<bool> IsInstanceAdminAuthorized(int eveCharacterId, int instanceId)
         {
             return await _instanceRepo.IsInstanceAdminAsync(instanceId, eveCharacterId);
+        }
+
+        /// <summary>
+        /// Returns the instance a map belongs to, or null when the map is unknown or orphaned.
+        /// </summary>
+        public async Task<int?> GetMapInstanceIdAsync(int mapId)
+        {
+            var map = await _mapRepo.GetById(mapId);
+            return map?.WHInstanceId;
         }
     }
 }

--- a/src/WHMapper/Services/EveMapper/EveMapperHelper.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperHelper.cs
@@ -160,11 +160,11 @@ namespace WHMapper.Services.EveMapper
             if (system_constellation == null)
                 throw new InvalidDataException("Constellation not found");
 
-            var system_region = await _eveMapperEntity.GetRegion(system_constellation!.RegionId);
+            var system_region = await _eveMapperEntity.GetRegion(system_constellation.RegionId);
             if (system_region == null)
                 throw new InvalidDataException("Region not found");
 
-            return await GetWHClass(system_region!.Name, system_constellation!.Name, whSystem.Name, whSystem.SecurityStatus);
+            return await GetWHClass(system_region.Name, system_constellation.Name, whSystem.Name, whSystem.SecurityStatus);
         }
 
     public Task<EveSystemType> GetWHClass(string regionName, string constellationName, string systemName, float securityStatus)
@@ -234,7 +234,7 @@ namespace WHMapper.Services.EveMapper
             WHEffect effect = WHEffect.None;
             if (IsWormhole(systemName))//WH system
             {
-                IEnumerable<SDESolarSystem>? sdeWormholesInfos = await _sdeServices!.SearchSystem(systemName);
+                IEnumerable<SDESolarSystem>? sdeWormholesInfos = await _sdeServices.SearchSystem(systemName);
                 SDESolarSystem? sdeInfos = sdeWormholesInfos?.FirstOrDefault();
 
                 if (sdeInfos != null && sdeInfos.SecondarySun != null)
@@ -279,12 +279,12 @@ namespace WHMapper.Services.EveMapper
 
             if (IsWormhole(wh.Name))//WH system
             {
-                EveSystemType whClass = await GetWHClass(system_region!.Name, system_constellation.Name, system.Name, system.SecurityStatus);
+                EveSystemType whClass = await GetWHClass(system_region.Name, system_constellation.Name, system.Name, system.SecurityStatus);
                 WHEffect whEffect = await GetSystemEffect(system.Name);
                 IList<EveSystemEffect>? effectDetails = GetWHEffectDetails(whEffect, whClass);
                 IList<WormholeType>? statics = null;
 
-                IEnumerable<KeyValuePair<string, string>>? whStatics = await _anoikServices!.GetSystemStatics(wh.Name);
+                IEnumerable<KeyValuePair<string, string>>? whStatics = await _anoikServices.GetSystemStatics(wh.Name);
                 
                 await EnsureWormholeTypesInitializedAsync();
                 if (whStatics!=null && whStatics.Any() && _whTypes != null && _whTypes.Any()) 
@@ -294,7 +294,7 @@ namespace WHMapper.Services.EveMapper
 
                 res = new EveSystemNodeModel(wh, note, system_region.Name, system_constellation.Name, whClass, whEffect, effectDetails, statics);
             }
-            else if (system_region!.Name == REGION_POCHVVEN_NAME)//trig system
+            else if (system_region.Name == REGION_POCHVVEN_NAME)//trig system
             {
                 res = new EveSystemNodeModel(wh, note, system_region.Name, system_constellation.Name, EveSystemType.Pochven, WHEffect.None, null, null);
             }

--- a/src/WHMapper/Services/EveMapper/EveMapperHelper.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperHelper.cs
@@ -289,7 +289,7 @@ namespace WHMapper.Services.EveMapper
                 await EnsureWormholeTypesInitializedAsync();
                 if (whStatics!=null && whStatics.Any() && _whTypes != null && _whTypes.Any()) 
                 {
-                    statics = whStatics.Select(x => _whTypes.FirstOrDefault<WormholeType>(y => String.Equals(y.Name,x.Key,StringComparison.OrdinalIgnoreCase))).Where(y => y != null).ToList<WormholeType>();
+                    statics = whStatics.Select(x => _whTypes.FirstOrDefault(y => String.Equals(y.Name,x.Key,StringComparison.OrdinalIgnoreCase))).OfType<WormholeType>().ToList();
                 }
 
                 res = new EveSystemNodeModel(wh, note, system_region.Name, system_constellation.Name, whClass, whEffect, effectDetails, statics);

--- a/src/WHMapper/Services/EveMapper/EveMapperHelper.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperHelper.cs
@@ -58,7 +58,7 @@ namespace WHMapper.Services.EveMapper
 
             LoadEffectsFromJson();
 
-            _initWormholeTypesTask = Task.Run(InitWormholeTypeList);
+            _initWormholeTypesTask = Task.Run(InitWormholeTypeList, CancellationToken.None);
         }
 
         private async Task EnsureWormholeTypesInitializedAsync()

--- a/src/WHMapper/Services/EveMapper/EveMapperInstanceService.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperInstanceService.cs
@@ -49,7 +49,6 @@ namespace WHMapper.Services.EveMapper
                     return null;
                 }
 
-                // Check if an instance already exists for this owner
                 var existingInstance = await _instanceRepository.GetByOwnerAsync(ownerEntityId);
                 if (existingInstance != null)
                 {
@@ -57,7 +56,6 @@ namespace WHMapper.Services.EveMapper
                     return null;
                 }
 
-                // Create the instance
                 var instance = new WHInstance(
                     name,
                     ownerEntityId,
@@ -75,7 +73,6 @@ namespace WHMapper.Services.EveMapper
                     return null;
                 }
 
-                // Add the creator as the owner admin
                 var admin = await _instanceRepository.AddInstanceAdminAsync(
                     createdInstance.Id,
                     creatorCharacterId,
@@ -143,7 +140,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<bool> DeleteInstanceAsync(int instanceId, int requestingCharacterId)
         {
-            // Only owner can delete
             if (!await IsOwnerAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to delete instance {InstanceId} but is not owner", 
@@ -156,7 +152,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<WHInstanceAdmin?> AddAdminAsync(int instanceId, int characterId, string characterName, int requestingCharacterId)
         {
-            // Only existing admin can add new admin
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to add admin to instance {InstanceId} but is not admin",
@@ -169,7 +164,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<bool> RemoveAdminAsync(int instanceId, int characterIdToRemove, int requestingCharacterId)
         {
-            // Only admin can remove other admins
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to remove admin from instance {InstanceId} but is not admin",
@@ -201,7 +195,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<WHInstanceAccess?> AddAccessAsync(int instanceId, int eveEntityId, string eveEntityName, WHAccessEntity entityType, int requestingCharacterId)
         {
-            // Only admin can add access
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to add access to instance {InstanceId} but is not admin",
@@ -217,7 +210,6 @@ namespace WHMapper.Services.EveMapper
         {
             var emptyResult = new Dictionary<int, IEnumerable<int>>();
             
-            // Only admin can remove access
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to remove access from instance {InstanceId} but is not admin",
@@ -225,7 +217,6 @@ namespace WHMapper.Services.EveMapper
                 return (false, emptyResult);
             }
 
-            // Get the access to find the entity details before removing
             var accesses = await _instanceRepository.GetInstanceAccessesAsync(instanceId);
             var accessToRemove = accesses?.FirstOrDefault(a => a.Id == accessId);
             
@@ -264,7 +255,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<WHMap?> CreateMapAsync(int instanceId, string mapName, int requestingCharacterId)
         {
-            // Only admin can create maps
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to create map in instance {InstanceId} but is not admin",
@@ -278,7 +268,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<bool> DeleteMapAsync(int instanceId, int mapId, int requestingCharacterId)
         {
-            // Only admin can delete maps
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to delete map from instance {InstanceId} but is not admin",
@@ -286,7 +275,6 @@ namespace WHMapper.Services.EveMapper
                 return false;
             }
 
-            // Verify map belongs to instance
             var map = await _mapRepository.GetById(mapId);
             if (map == null || map.WHInstanceId != instanceId)
             {
@@ -323,7 +311,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<IEnumerable<WHMapAccess>?> GetMapAccessesAsync(int instanceId, int mapId, int requestingCharacterId)
         {
-            // Only admin can view map accesses
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to view map accesses for map {MapId} but is not admin",
@@ -331,7 +318,6 @@ namespace WHMapper.Services.EveMapper
                 return null;
             }
 
-            // Verify map belongs to instance
             var map = await _mapRepository.GetById(mapId);
             if (map == null || map.WHInstanceId != instanceId)
             {
@@ -344,7 +330,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<WHMapAccess?> AddMapAccessAsync(int instanceId, int mapId, int eveEntityId, string eveEntityName, WHAccessEntity entityType, int requestingCharacterId)
         {
-            // Only admin can add map access
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to add map access for map {MapId} but is not admin",
@@ -352,7 +337,6 @@ namespace WHMapper.Services.EveMapper
                 return null;
             }
 
-            // Verify map belongs to instance
             var map = await _mapRepository.GetById(mapId);
             if (map == null || map.WHInstanceId != instanceId)
             {
@@ -366,7 +350,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<bool> RemoveMapAccessAsync(int instanceId, int mapId, int accessId, int requestingCharacterId)
         {
-            // Only admin can remove map access
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to remove map access from map {MapId} but is not admin",
@@ -374,7 +357,6 @@ namespace WHMapper.Services.EveMapper
                 return false;
             }
 
-            // Verify map belongs to instance
             var map = await _mapRepository.GetById(mapId);
             if (map == null || map.WHInstanceId != instanceId)
             {
@@ -387,7 +369,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<bool> ClearMapAccessesAsync(int instanceId, int mapId, int requestingCharacterId)
         {
-            // Only admin can clear map accesses
             if (!await IsAdminAsync(instanceId, requestingCharacterId))
             {
                 _logger.LogWarning("Character {CharacterId} attempted to clear map accesses for map {MapId} but is not admin",
@@ -395,7 +376,6 @@ namespace WHMapper.Services.EveMapper
                 return false;
             }
 
-            // Verify map belongs to instance
             var map = await _mapRepository.GetById(mapId);
             if (map == null || map.WHInstanceId != instanceId)
             {
@@ -408,7 +388,6 @@ namespace WHMapper.Services.EveMapper
 
         public async Task<bool> HasMapAccessAsync(int instanceId, int mapId, int characterId, int? corporationId, int? allianceId)
         {
-            // First check if user has instance access
             var hasInstanceAccess = await HasAccessAsync(instanceId, characterId, corporationId, allianceId);
             if (!hasInstanceAccess)
                 return false;
@@ -417,7 +396,6 @@ namespace WHMapper.Services.EveMapper
             if (await IsAdminAsync(instanceId, characterId))
                 return true;
 
-            // Check map-level access
             return await _mapAccessRepository.HasMapAccessAsync(mapId, characterId, corporationId, allianceId);
         }
 

--- a/src/WHMapper/Services/EveMapper/EveMapperRealTimeService.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperRealTimeService.cs
@@ -437,39 +437,39 @@ public class EveMapperRealTimeService : IEveMapperRealTimeService
         return new Dictionary<int, KeyValuePair<int, int>?>();
     }
 
-    public async Task NotifyMapAdded(int accountID,int mapId)
+    public async Task NotifyMapAdded(int accountID, int instanceId, int mapId)
     {
-        await SendSafeAsync(accountID, "SendMapAdded", mapId);
+        await SendSafeAsync(accountID, "SendMapAdded", instanceId, mapId);
     }
 
-    public async Task NotifyMapRemoved(int accountID,int mapId)
+    public async Task NotifyMapRemoved(int accountID, int instanceId, int mapId)
     {
-        await SendSafeAsync(accountID, "SendMapRemoved", mapId);
+        await SendSafeAsync(accountID, "SendMapRemoved", instanceId, mapId);
     }
 
-    public async Task NotifyMapNameChanged(int accountID,int mapId, string newName)
+    public async Task NotifyMapNameChanged(int accountID, int instanceId, int mapId, string newName)
     {
-        await SendSafeAsync(accountID, "SendMapNameChanged", mapId, newName);
+        await SendSafeAsync(accountID, "SendMapNameChanged", instanceId, mapId, newName);
     }
 
-    public async Task NotifyAllMapsRemoved(int accountID)
+    public async Task NotifyAllMapsRemoved(int accountID, int instanceId)
     {
-        await SendSafeAsync(accountID, "SendAllMapsRemoved");
+        await SendSafeAsync(accountID, "SendAllMapsRemoved", instanceId);
     }
 
-    public async Task NotifyMapAccessesAdded(int accountID,int mapId, IEnumerable<int> accessIds)
+    public async Task NotifyMapAccessesAdded(int accountID, int instanceId, int mapId, IEnumerable<int> accessIds)
     {
-        await SendSafeAsync(accountID, "SendMapAccessesAdded", mapId, accessIds);
+        await SendSafeAsync(accountID, "SendMapAccessesAdded", instanceId, mapId, accessIds);
     }
 
-    public async Task NotifyMapAccessRemoved(int accountID,int mapId, int accessId)
+    public async Task NotifyMapAccessRemoved(int accountID, int instanceId, int mapId, int accessId)
     {
-        await SendSafeAsync(accountID, "SendMapAccessRemoved", mapId, accessId);
+        await SendSafeAsync(accountID, "SendMapAccessRemoved", instanceId, mapId, accessId);
     }
 
-    public async Task NotifyMapAllAccessesRemoved(int accountID,int mapId)
+    public async Task NotifyMapAllAccessesRemoved(int accountID, int instanceId, int mapId)
     {
-        await SendSafeAsync(accountID, "SendMapAllAccessesRemoved", mapId);
+        await SendSafeAsync(accountID, "SendMapAllAccessesRemoved", instanceId, mapId);
     }
 
     public async Task NotifyUserOnMapConnected(int accountID,int mapId)
@@ -582,6 +582,16 @@ public class EveMapperRealTimeService : IEveMapperRealTimeService
     public async Task LeaveMap(int accountID, int mapId)
     {
         await SendSafeAsync(accountID, "LeaveMap", mapId);
+    }
+
+    public async Task JoinInstance(int accountID, int instanceId)
+    {
+        await SendSafeAsync(accountID, "JoinInstance", instanceId);
+    }
+
+    public async Task LeaveInstance(int accountID, int instanceId)
+    {
+        await SendSafeAsync(accountID, "LeaveInstance", instanceId);
     }
 
     public async Task<int> GetTotalConnectedUsers(int accountID)

--- a/src/WHMapper/Services/EveMapper/EveMapperSearch.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperSearch.cs
@@ -95,7 +95,7 @@ namespace WHMapper.Services.EveMapper
                                 Result<Character> characterResult = await _eveAPIServices.CharacterServices.GetCharacter(characterId);
                                 if (characterResult.IsSuccess && characterResult.Data != null)
                                     while (!eveEntityResults.TryAdd(new CharacterEntity(characterId, characterResult.Data), 100, token))
-                                        await Task.Delay(1);
+                                        await Task.Delay(1, token);
 
                                 await Task.Yield();
                             });
@@ -114,7 +114,7 @@ namespace WHMapper.Services.EveMapper
                                 Result<Corporation> corpo = await _eveAPIServices.CorporationServices.GetCorporation(corpoId);
                                 if (corpo.IsSuccess && corpo.Data != null)
                                     while (!eveEntityResults.TryAdd(new CorporationEntity(corpoId, corpo.Data), 100, token))
-                                        await Task.Delay(1);
+                                        await Task.Delay(1, token);
 
                                 await Task.Yield();
                             });
@@ -132,7 +132,7 @@ namespace WHMapper.Services.EveMapper
                                 Result<Alliance> alliance = await _eveAPIServices.AllianceServices.GetAlliance(allianceId);
                                 if (alliance.IsSuccess && alliance.Data != null)
                                     while (!eveEntityResults.TryAdd(new AllianceEntity(allianceId, alliance.Data), 100, token))
-                                        await Task.Delay(1);
+                                        await Task.Delay(1, token);
 
                                 await Task.Yield();
                             });

--- a/src/WHMapper/Services/EveMapper/EveMapperSearch.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperSearch.cs
@@ -62,7 +62,12 @@ namespace WHMapper.Services.EveMapper
                         CancellationToken = cancellationToken
                     };
 
-                    
+
+                    if (string.IsNullOrEmpty(_UID.ClientId))
+                    {
+                        _logger.LogError("Search {Value}, No client id to search", value);
+                        return null;
+                    }
                     var defaultAccount = await _userManagement.GetPrimaryAccountAsync(_UID.ClientId);
                     if (defaultAccount == null)
                     {

--- a/src/WHMapper/Services/EveMapper/EveMapperService.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperService.cs
@@ -20,10 +20,11 @@ public class EveMapperService : IEveMapperService
 
     private async Task<TEntity?> Get<TEntity, TEveApiEntity>(
         int key,
-        Func<IEveAPIServices, Task<TEveApiEntity>> getEveApiEntityAction,
+        Func<IEveAPIServices, Task<TEveApiEntity?>> getEveApiEntityAction,
         Func<TEveApiEntity, TEntity> entityMap
     )
         where TEntity : AEveEntity
+        where TEveApiEntity : class
     {
         try
         {
@@ -36,7 +37,7 @@ public class EveMapperService : IEveMapperService
 
             // Get from api if cache is empty
             var apiResult = await getEveApiEntityAction.Invoke(_eveApiService);
-            if (EqualityComparer<TEveApiEntity>.Default.Equals(apiResult, default(TEveApiEntity)))
+            if (apiResult is null)
             {
                 _logger.LogWarning("{entityname} with Id {key} not found", typeof(TEntity).Name, key);
                 return null;
@@ -44,7 +45,7 @@ public class EveMapperService : IEveMapperService
             else
             {
                 // Add to cache (fire and forget) and return the entity
-                var entity = entityMap(apiResult!);
+                var entity = entityMap(apiResult);
                 if (entity != null)
                 {
                     await _cacheService.AddAsync(entity);

--- a/src/WHMapper/Services/EveMapper/EveMapperTracker.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperTracker.cs
@@ -61,7 +61,6 @@ public class EveMapperTracker : IEveMapperTracker
         
         _logger.LogInformation("EveMapperTracker instance {InstanceId} disposing...", _instanceId);
         
-        // Cancel all tracking tokens
         foreach (var kvp in _ctss)
         {
             try
@@ -78,7 +77,6 @@ public class EveMapperTracker : IEveMapperTracker
             }
         }
         
-        // Wait for all tasks to complete with timeout
         var allTasks = _trackingTasks.Values.SelectMany(t => t).ToArray();
         if (allTasks.Length > 0)
         {
@@ -101,7 +99,6 @@ public class EveMapperTracker : IEveMapperTracker
             }
         }
         
-        // Dispose all CancellationTokenSources
         foreach (var kvp in _ctss)
         {
             try
@@ -143,14 +140,12 @@ public class EveMapperTracker : IEveMapperTracker
         {
             _logger.LogInformation("[{InstanceId}] StartTracking called for account {AccountId}", _instanceId, accountID);
 
-            // Stop existing tracking first if any
             if (_ctss.ContainsKey(accountID))
             {
                 _logger.LogInformation("[{InstanceId}] Stopping existing tracking for account {AccountId} before starting new one", _instanceId, accountID);
                 await StopTrackingInternal(accountID);
             }
 
-            // Create new CancellationTokenSource
             var cts = new CancellationTokenSource();
             if (!_ctss.TryAdd(accountID, cts))
             {
@@ -161,7 +156,6 @@ public class EveMapperTracker : IEveMapperTracker
 
             await ClearTracking(accountID);
             
-            // Start tracking tasks and store references
             var locationTask = Task.Run(() => HandleTrackLocationAsync(accountID, cts.Token), cts.Token);
             var shipTask = Task.Run(() => HandleTrackShipAsync(accountID, cts.Token), cts.Token);
             
@@ -197,7 +191,6 @@ public class EveMapperTracker : IEveMapperTracker
     {
         _logger.LogInformation("[{InstanceId}] StopTrackingInternal called for account {AccountId}", _instanceId, accountID);
 
-        // Cancel the token
         if (_ctss.TryRemove(accountID, out var cts))
         {
             if (cts != null)
@@ -215,7 +208,6 @@ public class EveMapperTracker : IEveMapperTracker
                     }
                 }
                 
-                // Wait for tasks to complete
                 if (_trackingTasks.TryRemove(accountID, out var tasks))
                 {
                     try

--- a/src/WHMapper/Services/EveMapper/EveMapperUserManagementService.cs
+++ b/src/WHMapper/Services/EveMapper/EveMapperUserManagementService.cs
@@ -64,7 +64,6 @@ public class EveMapperUserManagementService : IEveMapperUserManagementService
         var user = new WHMapperUser(id, portrait?.Picture64x64 ?? string.Empty);
 
 
-        // Check if the user is already in the list
         if (_whMapperUsers.TryGetValue(clientId, out WHMapperUser[]? users) && users.Any(user => user.Id == id))
         {
             await _tokenProvider.SaveToken(token);
@@ -72,7 +71,6 @@ public class EveMapperUserManagementService : IEveMapperUserManagementService
             return;
         }
 
-        // Add or update the user list
         _whMapperUsers.AddOrUpdate(clientId, new[] { user }, (_, existingUsers) => existingUsers.Append(user).ToArray());
 
         await _tokenProvider.SaveToken(token);
@@ -101,7 +99,6 @@ public class EveMapperUserManagementService : IEveMapperUserManagementService
             var updatedUsers = users.Where(user => user.Id != id).ToArray();
             _whMapperUsers.AddOrUpdate(clientId, updatedUsers, (_, _) => updatedUsers);
 
-            // Only clear the token if the user exists
             if (users.Any(user => user.Id == id))
             {
                 await _tokenProvider.ClearToken(accountId);
@@ -175,7 +172,6 @@ public class EveMapperUserManagementService : IEveMapperUserManagementService
             throw new ArgumentNullException(nameof(accountId), "Account not found");
         }
 
-        //set all accouts IsPrimary to false
         accounts.ToList().ForEach(account => account.IsPrimary = false);
         
 
@@ -184,10 +180,8 @@ public class EveMapperUserManagementService : IEveMapperUserManagementService
 
         account.IsPrimary = true;
         
-        // Update map access for all accounts based on the new primary account
         await UpdateAccountsMapAccessAsync(clientId);
         
-        // Notify listeners that the primary account has changed
         if (PrimaryAccountChanged != null)
         {
             await PrimaryAccountChanged.Invoke(clientId, id);
@@ -217,7 +211,6 @@ public class EveMapperUserManagementService : IEveMapperUserManagementService
         // Primary account always has map access
         primaryAccount.HasMapAccess = true;
 
-        // Get accessible maps for the primary account using a scoped service
         using var scope = _serviceProvider.CreateScope();
         var mapRepo = scope.ServiceProvider.GetRequiredService<IWHMapRepository>();
         var accessHelper = scope.ServiceProvider.GetRequiredService<IEveMapperAccessHelper>();
@@ -234,7 +227,6 @@ public class EveMapperUserManagementService : IEveMapperUserManagementService
             return;
         }
 
-        // Get the maps that the primary account has access to
         var primaryAccessibleMapIds = new List<int>();
         foreach (var map in allMaps)
         {
@@ -247,7 +239,6 @@ public class EveMapperUserManagementService : IEveMapperUserManagementService
         _logger.LogInformation("Primary account {PrimaryAccountId} has access to {MapCount} maps", 
             primaryAccount.Id, primaryAccessibleMapIds.Count);
 
-        // Check each secondary account's access to the primary's maps
         foreach (var account in accounts.Where(a => !a.IsPrimary))
         {
             bool hasAccessToAnyPrimaryMap = false;

--- a/src/WHMapper/Services/EveMapper/IEveMapperAccessHelper.cs
+++ b/src/WHMapper/Services/EveMapper/IEveMapperAccessHelper.cs
@@ -6,5 +6,17 @@
         public Task<bool> IsEveMapperUserAccessAuthorizedForAny(IEnumerable<int> eveCharacterIds);
         public Task<bool> IsEveMapperAdminAccessAuthorized(int eveCharacterId);
         public Task<bool> IsEveMapperMapAccessAuthorized(int eveCharacterId, int mapId);
+        public Task<bool> IsEveMapperInstanceAccessAuthorized(int eveCharacterId, int instanceId);
+
+        /// <summary>
+        /// Ids of every instance the character can access, through character, corporation or alliance.
+        /// </summary>
+        public Task<IEnumerable<int>> GetAccessibleInstanceIdsAsync(int eveCharacterId);
+        public Task<bool> IsInstanceAdminAuthorized(int eveCharacterId, int instanceId);
+
+        /// <summary>
+        /// Returns the instance a map belongs to, or null when the map is unknown or orphaned.
+        /// </summary>
+        public Task<int?> GetMapInstanceIdAsync(int mapId);
     }
 }

--- a/src/WHMapper/Services/EveMapper/IEveMapperInstanceService .cs
+++ b/src/WHMapper/Services/EveMapper/IEveMapperInstanceService .cs
@@ -28,9 +28,6 @@ namespace WHMapper.Services.EveMapper
             int creatorCharacterId,
             string creatorCharacterName);
 
-        /// <summary>
-        /// Gets an instance by ID
-        /// </summary>
         Task<WHInstance?> GetInstanceAsync(int instanceId);
 
         /// <summary>
@@ -43,9 +40,6 @@ namespace WHMapper.Services.EveMapper
         /// </summary>
         Task<IEnumerable<WHInstance>?> GetAdministeredInstancesAsync(int characterId);
 
-        /// <summary>
-        /// Gets all instances accessible by a character
-        /// </summary>
         Task<IEnumerable<WHInstance>?> GetAccessibleInstancesAsync(int characterId, int? corporationId, int? allianceId);
 
         /// <summary>
@@ -68,9 +62,6 @@ namespace WHMapper.Services.EveMapper
         /// </summary>
         Task<bool> RemoveAdminAsync(int instanceId, int characterIdToRemove, int requestingCharacterId);
 
-        /// <summary>
-        /// Gets all admins of an instance
-        /// </summary>
         Task<IEnumerable<WHInstanceAdmin>?> GetAdminsAsync(int instanceId);
 
         /// <summary>
@@ -94,9 +85,6 @@ namespace WHMapper.Services.EveMapper
         /// <returns>A tuple containing: success flag, and dictionary of removed map accesses (mapId -> list of accessIds)</returns>
         Task<(bool Success, IDictionary<int, IEnumerable<int>> RemovedMapAccesses)> RemoveAccessAsync(int instanceId, int accessId, int requestingCharacterId);
 
-        /// <summary>
-        /// Gets all access entries for an instance
-        /// </summary>
         Task<IEnumerable<WHInstanceAccess>?> GetAccessesAsync(int instanceId);
 
         /// <summary>
@@ -114,9 +102,6 @@ namespace WHMapper.Services.EveMapper
         /// </summary>
         Task<bool> DeleteMapAsync(int instanceId, int mapId, int requestingCharacterId);
 
-        /// <summary>
-        /// Gets all maps in an instance
-        /// </summary>
         Task<IEnumerable<WHMap>?> GetMapsAsync(int instanceId);
 
         /// <summary>
@@ -132,9 +117,6 @@ namespace WHMapper.Services.EveMapper
 
         #region Map Access Management
 
-        /// <summary>
-        /// Gets all access entries for a specific map
-        /// </summary>
         Task<IEnumerable<WHMapAccess>?> GetMapAccessesAsync(int instanceId, int mapId, int requestingCharacterId);
 
         /// <summary>

--- a/src/WHMapper/Services/EveMapper/IEveMapperRealTimeService.cs
+++ b/src/WHMapper/Services/EveMapper/IEveMapperRealTimeService.cs
@@ -3,479 +3,80 @@ using WHMapper.Models.Db.Enums;
 namespace WHMapper.Services.EveMapper;
 
 /// <summary>
-/// Interface for the Eve Mapper synchronization service.
+/// Client side of the SignalR notification hub: one connection per EVE account, exposing incoming
+/// hub notifications as events and outgoing hub calls as Notify* methods.
 /// </summary>
 public interface IEveMapperRealTimeService : IAsyncDisposable
 {
-    /// <summary>
-    /// Triggered when a user connects.
-    /// </summary>
-    /// <param name="user">The username of the connected user.</param>
     event Func<int, Task> UserConnected;
-
-    /// <summary>
-    /// Triggered when a user disconnects.
-    /// </summary>
-    /// <param name="accountID">The accountID of the disconnected user.</param>
     event Func<int, Task> UserDisconnected;
-
-    /// <summary>
-    /// Triggered when a user updates their position.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user.</param>
-    /// <param name="mapId">The ID of the map where the user is located.</param>
-    /// <param name="wormholeId">The ID of the wormhole where the user is located.</param>
     event Func<int, int,int, Task> UserPosition;
-
-/*
-    /// <summary>
-    /// Triggered when there is an update of users' positions.
-    /// </summary>
-    /// <param name="usersPosition">A dictionary containing usernames and their corresponding system names.</param>
-    event Func<IDictionary<string, string>, Task> UsersPosition;
-*/
-    /// <summary>
-    /// Triggered when a wormhole is added.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who added the wormhole.</param>
-    /// <param name="mapId">The ID of the map where the wormhole was added.</param>
-    /// <param name="wormholeId">The ID of the added wormhole.</param>
     event Func<int, int, int, Task> WormholeAdded;
-
-    /// <summary>
-    /// Triggered when a wormhole is removed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who removed the wormhole.</param>
-    /// <param name="mapId">The ID of the map where the wormhole was removed.</param>
-    /// <param name="wormholeId">The ID of the removed wormhole.</param>
     event Func<int, int, int, Task> WormholeRemoved;
-
-    /// <summary>
-    /// Triggered when a link is added.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who added the link.</param>
-    /// <param name="mapId">The ID of the map where the link was added.</param>
-    /// <param name="linkId">The ID of the added link.</param>
     event Func<int, int, int, Task> LinkAdded;
-
-    /// <summary>
-    /// Triggered when a link is removed.
-    /// </summary>
-    /// <param name="user">The username of the user who removed the link.</param>
-    /// <param name="mapId">The ID of the map where the link was removed.</param>
-    /// <param name="linkId">The ID of the removed link.</param>
     event Func<int, int, int, Task> LinkRemoved;
-
-    /// <summary>
-    /// Triggered when a wormhole is moved.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who moved the wormhole.</param>
-    /// <param name="mapId">The ID of the map where the wormhole was moved.</param>
-    /// <param name="wormholeId">The ID of the moved wormhole.</param>
-    /// <param name="posX">The new X position of the wormhole.</param>
-    /// <param name="posY">The new Y position of the wormhole.</param>
     event Func<int, int, int, double, double, Task> WormholeMoved;
-
-    /// <summary>
-    /// Triggered when a link is changed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who changed the link.</param>
-    /// <param name="mapId">The ID of the map where the link was changed.</param>
-    /// <param name="linkId">The ID of the changed link.</param>
-    /// <param name="eolStatus">The end-of-life status of the link.</param>
-    /// <param name="size">The size of the link.</param>
-    /// <param name="mass">The mass status of the link.</param>
     event Func<int, int, int, SystemLinkEolStatus, SystemLinkSize, SystemLinkMassStatus, Task> LinkChanged;
-
-    /// <summary>
-    /// Triggered when a wormhole name extension is changed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who changed the wormhole name extension.</param>
-    /// <param name="mapId">The ID of the map where the wormhole name extension was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed name extension.</param>
-    /// <param name="extension">The new name extension of the wormhole, or null if removed.</param>
     event Func<int, int, int, char?, Task> WormholeNameExtensionChanged;
-
-    /// <summary>
-    /// Triggered when a wormhole signature is changed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who changed the wormhole signature.</param>
-    /// <param name="mapId">The ID of the map where the wormhole signature was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed signature.</param>
     event Func<int, int, int, Task> WormholeSignaturesChanged;
-
-    /// <summary>
-    /// Triggered when a wormhole is locked or unlocked.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who changed the lock status of the wormhole.</param>
-    /// <param name="mapId">The ID of the map where the wormhole lock status was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed lock status.</param>
-    /// <param name="locked">Indicates if the wormhole is locked.</param>
     event Func<int, int, int, bool, Task> WormholeLockChanged;
-
-    /// <summary>
-    /// Triggered when a wormhole system status is changed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who changed the wormhole system status.</param>
-    /// <param name="mapId">The ID of the map where the wormhole system status was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed system status.</param>
-    /// <param name="systemStatus">The new system status of the wormhole.</param>
     event Func<int, int, int, WHSystemStatus, Task> WormholeSystemStatusChanged;
-
-    /// <summary>
-    /// Triggered when a wormhole alternate name is changed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who changed the wormhole alternate name.</param>
-    /// <param name="mapId">The ID of the map where the wormhole alternate name was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed alternate name.</param>
-    /// <param name="alternateName">The new alternate name of the wormhole, or null if removed.</param>
     event Func<int, int,int, string?, Task> WormholeAlternateNameChanged;
-
-    /// <summary>
-    /// Triggered when a map is added.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who added the map.</param>
-    /// <param name="mapId">The ID of the added map.</param>
     event Func<int, int, Task> MapAdded;
-
-    /// <summary>
-    /// Triggered when a map is removed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who removed the map.</param>
-    /// <param name="mapId">The ID of the removed map.</param>
     event Func<int, int, Task> MapRemoved;
-
-    /// <summary>
-    /// Triggered when a map name is changed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who changed the map name.</param>
-    /// <param name="mapId">The ID of the map with the changed name.</param>
     event Func<int, int, string, Task> MapNameChanged;
-
-
-    /// <summary>
-    /// Triggered when all maps are removed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who removed all maps.</param>
     event Func<int, Task> AllMapsRemoved;
-
-    /// <summary>
-    /// Triggered when accesses are added to a map.
-    /// </summary>
     event Func<int, int, IEnumerable<int>, Task> MapAccessesAdded;
-
-    /// <summary>
-    /// Triggered when an access is removed from a map.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who removed the access.</param>
     event Func<int, int, int, Task> MapAccessRemoved;
-
-    /// <summary>
-    /// Triggered when all accesses are removed from a map.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who removed all accesses.</param>
     event Func<int, int, Task> MapAllAccessesRemoved;
-
-    /// <summary>
-    /// Triggered when a user connects to a map.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who connected to the map.</param>
-    /// <param name="mapId">The ID of the map where the user connected.</param>
     event Func<int, int, Task> UserOnMapConnected;
-
-    /// <summary>
-    /// Triggered when a user disconnects from a map.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who disconnected from the map.</param>
-    /// <param name="mapId">The ID of the map where the user disconnected.</param>
     event Func<int, int, Task> UserOnMapDisconnected;
-
-    /// <summary>
-    /// Triggered when an access is added to an instance.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who added the access.</param>
-    /// <param name="instanceId">The ID of the instance.</param>
-    /// <param name="accessId">The ID of the access that was added.</param>
     event Func<int, int, int, Task> InstanceAccessAdded;
-
-    /// <summary>
-    /// Triggered when an access is removed from an instance.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who removed the access.</param>
-    /// <param name="instanceId">The ID of the instance.</param>
-    /// <param name="accessId">The ID of the access that was removed.</param>
     event Func<int, int, int, Task> InstanceAccessRemoved;
-
-    /// <summary>
-    /// Triggered when an instance is removed.
-    /// </summary>
-    /// <param name="accountID">The accountID of the user who removed the instance.</param>
-    /// <param name="instanceId">The ID of the removed instance.</param>
     event Func<int, int, Task> InstanceRemoved;
 
-    /// <summary>
-    /// Starts the real-time service.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains a boolean indicating success or failure.</returns>
     Task<bool> Start(int accountID);
-
-    /// <summary>
-    /// Stops the real-time service.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains a boolean indicating success or failure.</returns>
     Task<bool> Stop(int accountID);
+    Task<bool> IsConnected(int accountID);
 
-    /// <summary>
-    /// Notifies the server of the user's position.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the user is located.</param>
-    /// <param name="wormholeId">The ID of the wormhole where the user is located.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyUserPosition(int accountID, int mapId, int wormholeId);
-
-    /// <summary>
-    /// Notifies the server that a wormhole has been added.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the wormhole was added.</param>
-    /// <param name="wormholeId">The ID of the added wormhole.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyWormoleAdded(int accountID, int mapId, int wormholeId);
-
-    /// <summary>
-    /// Notifies the server that a wormhole has been removed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the wormhole was removed.</param>
-    /// <param name="wormholeId">The ID of the removed wormhole.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyWormholeRemoved(int accountID, int mapId, int wormholeId);
-
-    /// <summary>
-    /// Notifies the server that a link has been added.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the link was added.</param>
-    /// <param name="linkId">The ID of the added link.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyLinkAdded(int accountID, int mapId, int linkId);
-
-    /// <summary>
-    /// Notifies the server that a link has been removed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the link was removed.</param>
-    /// <param name="linkId">The ID of the removed link.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyLinkRemoved(int accountID, int mapId, int linkId);
-
-    /// <summary>
-    /// Notifies the server that a wormhole has been moved.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the wormhole was moved.</param>
-    /// <param name="wormholeId">The ID of the moved wormhole.</param>
-    /// <param name="posX">The new X position of the wormhole.</param>
-    /// <param name="posY">The new Y position of the wormhole.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyWormholeMoved(int accountID, int mapId, int wormholeId, double posX, double posY);
-
-    /// <summary>
-    /// Notifies the server that a link has been changed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the link was changed.</param>
-    /// <param name="linkId">The ID of the link that changed.</param>
-    /// <param name="eolStatus">The end-of-life status of the link.</param>
-    /// <param name="size">The new size of the link.</param>
-    /// <param name="mass">The new mass status of the link.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyLinkChanged(int accountID, int mapId, int linkId, SystemLinkEolStatus eolStatus, SystemLinkSize size, SystemLinkMassStatus mass);
-
-    /// <summary>
-    /// Notifies the server that a wormhole name extension has been changed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the wormhole name extension was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed name extension.</param>
-    /// <param name="extension">The new name extension of the wormhole, or null if removed.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyWormholeNameExtensionChanged(int accountID, int mapId, int wormholeId, char? extension);
-
-    /// <summary>
-    /// Notifies the server that a wormhole signature has been changed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the wormhole signature was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed signature.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyWormholeSignaturesChanged(int accountID, int mapId, int wormholeId);
-
-    /// <summary>
-    /// Notifies the server that a wormhole lock status has been changed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the wormhole lock status was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed lock status.</param>
-    /// <param name="locked">Indicates if the wormhole is locked.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyWormholeLockChanged(int accountID, int mapId, int wormholeId, bool locked);
-
-    /// <summary>
-    /// Notifies the server that a wormhole system status has been changed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the wormhole system status was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed system status.</param>
-    /// <param name="systemStatus">The new system status of the wormhole.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyWormholeSystemStatusChanged(int accountID, int mapId, int wormholeId, WHSystemStatus systemStatus);
-
-
-    /// <summary>
-    /// Notifies the server that an alternate name has been changed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the alternate name was changed.</param>
-    /// <param name="wormholeId">The ID of the wormhole with the changed alternate name.</param>
-    /// <param name="alternateName">The new alternate name of the wormhole, or null if removed.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyAlternameNameChanged(int accountID, int mapId, int wormholeId, string? alternateName);
-
-    /// <summary>
-    /// Gets the position of connected users.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains a dictionary of usernames and their corresponding positions.</returns>
-    Task<IDictionary<int, KeyValuePair<int, int>?>> GetConnectedUsersPosition(int accountID);
-
-    /// <summary>
-    /// Notifies the server that a map has been added.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the added map.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task NotifyMapAdded(int accountID, int mapId);
-
-    /// <summary>
-    /// Notifies the server that a map has been removed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the removed map.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task NotifyMapRemoved(int accountID, int mapId);
-
-    /// <summary>
-    /// Notifies the server that a map name has been changed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map with the changed name.</param>
-    /// <param name="newName">The new name of the map.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task NotifyMapNameChanged(int accountID, int mapId, string newName);
-
-    /// <summary>
-    /// Notifies the server that all maps have been removed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task NotifyAllMapsRemoved(int accountID);
-
-    /// <summary>
-    /// Notifies the server that accesses have been added to a map.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where accesses were added.</param>
-    /// <param name="accessIds">The IDs of the added accesses.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task NotifyMapAccessesAdded(int accountID, int mapId, IEnumerable<int> accessIds);
-
-    /// <summary>
-    /// Notifies the server that an access has been removed from a map.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the access was removed.</param>
-    /// <param name="accessId">The ID of the removed access.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task NotifyMapAccessRemoved(int accountID, int mapId, int accessId);
-
-    /// <summary>
-    /// Notifies the server that all accesses have been removed from a map.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where all accesses were removed.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    Task NotifyMapAllAccessesRemoved(int accountID, int mapId);
-
-    /// <summary>
-    /// Notifies the server that a user has connected to a map.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the user connected.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyUserOnMapConnected(int accountID, int mapId);
-
-    /// <summary>
-    /// Notifies the server that a user has disconnected from a map.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="mapId">The ID of the map where the user disconnected.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyUserOnMapDisconnected(int accountID, int mapId);
 
-    /// <summary>
-    /// Notifies the server that an access has been added to an instance.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="instanceId">The ID of the instance.</param>
-    /// <param name="accessId">The ID of the access that was added.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
+    // Instance-scoped notifications: the hub authorizes the caller against instanceId before
+    // broadcasting, so it has to be passed explicitly even when a mapId is also present.
+    Task NotifyMapAdded(int accountID, int instanceId, int mapId);
+    Task NotifyMapRemoved(int accountID, int instanceId, int mapId);
+    Task NotifyMapNameChanged(int accountID, int instanceId, int mapId, string newName);
+    Task NotifyAllMapsRemoved(int accountID, int instanceId);
+    Task NotifyMapAccessesAdded(int accountID, int instanceId, int mapId, IEnumerable<int> accessIds);
+    Task NotifyMapAccessRemoved(int accountID, int instanceId, int mapId, int accessId);
+    Task NotifyMapAllAccessesRemoved(int accountID, int instanceId, int mapId);
     Task NotifyInstanceAccessAdded(int accountID, int instanceId, int accessId);
-
-    /// <summary>
-    /// Notifies the server that an access has been removed from an instance.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="instanceId">The ID of the instance.</param>
-    /// <param name="accessId">The ID of the access that was removed.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyInstanceAccessRemoved(int accountID, int instanceId, int accessId);
-
-    /// <summary>
-    /// Notifies the server that an instance has been removed.
-    /// </summary>
-    /// <param name="accountID">The ID of the account.</param>
-    /// <param name="instanceId">The ID of the removed instance.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
     Task NotifyInstanceRemoved(int accountID, int instanceId);
 
     /// <summary>
-    /// Checks if the account is connected.
-    /// </summary>
-    /// <param name="accountID"></param>
-    /// <returns></returns>
-    Task<bool> IsConnected(int accountID);
-
-    /// <summary>
-    /// Joins the SignalR group for the specified map to receive map-scoped events.
+    /// Joining is what grants the connection the right to send and receive map- and
+    /// instance-scoped events; the hub re-checks access server-side.
     /// </summary>
     Task JoinMap(int accountID, int mapId);
-
-    /// <summary>
-    /// Leaves the SignalR group for the specified map.
-    /// </summary>
     Task LeaveMap(int accountID, int mapId);
+    Task JoinInstance(int accountID, int instanceId);
+    Task LeaveInstance(int accountID, int instanceId);
 
-    /// <summary>
-    /// Gets the total number of distinct accounts currently connected to the hub.
-    /// </summary>
+    Task<IDictionary<int, KeyValuePair<int, int>?>> GetConnectedUsersPosition(int accountID);
     Task<int> GetTotalConnectedUsers(int accountID);
-
-    /// <summary>
-    /// Gets the number of distinct accounts currently present on the given map.
-    /// </summary>
     Task<int> GetUserCountOnMap(int accountID, int mapId);
 }

--- a/src/WHMapper/Services/Metrics/WHMapperStoreMetrics.cs
+++ b/src/WHMapper/Services/Metrics/WHMapperStoreMetrics.cs
@@ -15,39 +15,31 @@ public class WHMapperStoreMetrics
 {
     private readonly ILogger<WHMapperStoreMetrics> _logger;
 
-    // WHMapperStoreMetrics
-    // Users Metrics
     private Counter<int> UsersConnectedCounter { get; }
     private Counter<int> UsersDisconnectedCounter { get; }
     private int _totalUsers = 0;
 
-    //Systems Metrics
     private Counter<int> SystemsAddedCounter { get; }
     private Counter<int> SystemsDeletedCounter { get; }
     private int _totalSystems = 0;
 
 
-    //Links Metrics
     private Counter<int> LinksAddedCounter { get; }
     private Counter<int> LinksDeletedCounter { get; }
     private int _totalLinks = 0;
 
-    //Maps Metrics
     private Counter<int> MapsCreatedCounter { get; }
     private Counter<int> MapsDeletedCounter { get; }
     private int _totalMaps = 0;
 
-    //Signatures Metrics
     private Counter<int> SignaturesCreatedCounter { get; }
     private Counter<int> SignaturesDeletedCounter { get; }
     private int _totalSignatures = 0;
 
-    //Notes Metrics
     private Counter<int> NotesCreatedCounter { get; }
     private Counter<int> NotesDeletedCounter { get; }
     private int _totalNotes = 0;
 
-    //Jump Logs Metrics
     private Counter<int> JumpLogsCreatedCounter { get; }
     private Counter<int> JumpLogsDeletedCounter { get; }
     private int _totalJumpLogs = 0;
@@ -116,7 +108,6 @@ public class WHMapperStoreMetrics
         }
     }
 
-    //WHMAPPER Metrics
     public void ConnectUser()
     {
         UsersConnectedCounter.Add(1);
@@ -128,7 +119,6 @@ public class WHMapperStoreMetrics
         Interlocked.Decrement(ref _totalUsers);
     }
     
-    //Maps Metrics
     public void CreateMap()
     {
         MapsCreatedCounter.Add(1);
@@ -145,7 +135,6 @@ public class WHMapperStoreMetrics
         Interlocked.Add(ref _totalMaps, -delCount);
     }
 
-    //Systems Metrics
     public void AddSystem()
     {
         SystemsAddedCounter.Add(1);
@@ -162,7 +151,6 @@ public class WHMapperStoreMetrics
         Interlocked.Add(ref _totalSystems, -delCount);
     }
 
-    //Links Metrics
     public void AddLink()
     {
         LinksAddedCounter.Add(1);
@@ -180,7 +168,6 @@ public class WHMapperStoreMetrics
         Interlocked.Add(ref _totalLinks, -delCount);
     }
 
-    //Signatures Metrics
     public void CreateSignature()
     {
         SignaturesCreatedCounter.Add(1);
@@ -197,7 +184,6 @@ public class WHMapperStoreMetrics
         Interlocked.Add(ref _totalSignatures, -delCount);
     }
 
-    //Notes Metrics
     public void CreateNote()
     {
         NotesCreatedCounter.Add(1);
@@ -214,7 +200,6 @@ public class WHMapperStoreMetrics
         Interlocked.Add(ref _totalNotes, -delCount);
     }
 
-    //Jump Logs Metrics
     public void CreateJumpLog()
     {
         JumpLogsCreatedCounter.Add(1);

--- a/src/WHMapper/Services/SDE/SDEServiceManager.cs
+++ b/src/WHMapper/Services/SDE/SDEServiceManager.cs
@@ -283,7 +283,7 @@ namespace WHMapper.Services.SDE
             {
                 var jumpSystemList = system.Stargates?.Values
                     .Select(stargate => collectionOfSolarSystems.FirstOrDefault(x => x.Stargates.ContainsKey(stargate.Destination)))
-                    .Where(s => s != null)
+                    .OfType<SDESolarSystem>()
                     .Select(s => new SolarSystem(s.SolarSystemID, s.Security))
                     .ToList() ?? new List<SolarSystem>();
 

--- a/src/WHMapper/WHMapper.csproj
+++ b/src/WHMapper/WHMapper.csproj
@@ -19,33 +19,33 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.*" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageReference Include="MudBlazor" Version="9.7.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.*" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.*" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Z.Blazor.Diagrams" Version="3.0.4.1" />
     <PackageReference Include="YamlDotNet" Version="18.*" />
     <PackageReference Include="FluentValidation" Version="12.*" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.*" />
     <PackageReference Include="FibonacciHeap" Version="2.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.*" />
     <PackageReference Include="Npgsql" Version="10.*" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.*" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.*" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.*" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.*" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.*" />
     <PackageReference Include="Z.Blazor.Diagrams.Algorithms" Version="3.0.4.1" />
-    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="1.17.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
… on authenticated identity

Two related authorization fixes for multi-tenant data isolation:

1. SignalR hub had no per-map access check. JoinMap and every map-scoped Send* method accepted a client-supplied mapId without verification, so any authenticated user could loop over sequential mapIds to receive (and inject) real-time intel for other corporations/alliances.
   - JoinMap now calls IsEveMapperMapAccessAuthorized server-side (HubException on denial) and records authorized mapIds per connection in _authorizedMaps.
   - Map-scoped Send* methods verify IsConnectionAuthorizedForMap before broadcasting. The expensive ESI+DB check runs once at JoinMap; Send* only does an in-memory lookup.

2. Authorization handlers keyed access decisions off the client-controlled client_uid cookie: when a primary account existed, they granted that account's rights without verifying it belonged to the authenticated principal, enabling cookie-fixation privilege escalation.
   - Both handlers now require the authenticated characterId (SSO claim) to be a member of the client_uid account group before honoring the primary account, otherwise fall back to checking the authenticated character.

Tests: hub tests updated for the new constructor dependency and JoinMap prerequisite; added two regression tests (denied join throws and does not join; presence updates without a prior JoinMap are ignored).