### PR TITLE
ci(cla): allow dependabot in cla-bot contributors

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -5,7 +5,8 @@
       "pfh59",
       "rdymade",
       "Blackout76",
-      "pkoelemij"
+      "pkoelemij",
+      "dependabot[bot]"
   ]
 }
 


### PR DESCRIPTION
## Problem

Every Dependabot PR fails the `verification/cla-signed` check (see #431).

Dependabot's commits are authored by the GitHub user `dependabot[bot]`, which was not present in the `contributors` list of [`.clabot`](.clabot), so cla-bot rejects them.

## Fix

Add `dependabot[bot]` to the `.clabot` contributors allowlist.

## Note

cla-bot reads `.clabot` from the repository's default branch, so #431 will only go green after this is merged to `main` (a re-run / new commit on that PR may be needed to re-trigger the check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)